### PR TITLE
Issue #27: Add Support for CommandLine Criteria and Sources

### DIFF
--- a/src/it/metricshub-connectors/src/main/connector/hardware/NvidiaSmi/NvidiaSmi.yaml
+++ b/src/it/metricshub-connectors/src/main/connector/hardware/NvidiaSmi/NvidiaSmi.yaml
@@ -14,7 +14,7 @@ connector:
     - NT
     - Linux
     criteria:
-    - type: osCommand
+    - type: commandLine
       commandLine: nvidia-smi
       expectedResult: Driver Version
       errorMessage: nvidia-smi not found at target host.
@@ -23,7 +23,7 @@ monitors:
     discovery:
       sources:
         source(1):
-          type: osCommand
+          type: commandLine
           commandLine: nvidia-smi -q
           timeout: 90
           computes:
@@ -62,7 +62,7 @@ monitors:
       - id
       sources:
         source(1):
-          type: osCommand
+          type: commandLine
           commandLine: nvidia-smi -q
           timeout: 90
           computes:
@@ -111,7 +111,7 @@ monitors:
       - id
       sources:
         source(1):
-          type: osCommand
+          type: commandLine
           commandLine: nvidia-smi -q
           timeout: 90
           computes:
@@ -150,7 +150,7 @@ monitors:
       - id
       sources:
         source(1):
-          type: osCommand
+          type: commandLine
           commandLine: nvidia-smi -q
           timeout: 90
           computes:
@@ -192,7 +192,7 @@ monitors:
       - id
       sources:
         source(1):
-          type: osCommand
+          type: commandLine
           commandLine: nvidia-smi -q
           timeout: 90
           computes:

--- a/src/it/metricshub-connectors/verify.groovy
+++ b/src/it/metricshub-connectors/verify.groovy
@@ -114,6 +114,7 @@ assert htmlText.indexOf("VMware ESXi - Disks (VMware)") > -1 : "platform-require
 assert htmlText.indexOf("VMware ESXi 4.x") > -1 : "platform-requirements: 'VMware ESXi 4.x' must be listed"
 assert htmlText.indexOf("VMware ESXi - Disks (IPMI)") > -1 : "platform-requirements: 'VMware ESXi - Disks (IPMI)' must be listed"
 assert htmlText.indexOf("VMware ESXi - Virtual Machines (SNMP)") > -1 : "platform-requirements: 'VMware ESXi - Virtual Machines (SNMP)' must be listed"
+assert htmlText.indexOf("Command Lines") > -1 : "platform-requirements: 'Command Lines' technology must be listed"
 
 // IpmiTool
 htmlText = new File(basedir, "target/site/connectors/ipmitool.html").text
@@ -257,3 +258,11 @@ assert htmlText.indexOf('id') > -1 : "MIB2: the 'id' attribute must be listed fo
 assert htmlText.indexOf('name') > -1 : "MIB2: the 'name' attribute must be listed for the Network monitor"
 assert htmlText.indexOf('physical_address') > -1 : "MIB2: the 'physical_address' attribute must be listed for the Network monitor"
 assert htmlText.indexOf('physical_address_type') > -1 : "MIB2: the 'physical_address_type' attribute must be listed for the Network monitor"
+
+// Nvidia-Smi
+htmlText = new File(basedir, "target/site/connectors/nvidiasmi.html").text
+assert htmlText.indexOf("Any system with Nvidia GPUs") > -1 : "NvidiaSmi: Unexpected Typical platform"
+assert htmlText.indexOf("Microsoft Windows, Linux") > -1 : "NvidiaSmi: Unexpected Operating Systems"
+assert htmlText.indexOf("NVIDIA drivers with NVIDIA-SMI support") > -1 : "NvidiaSmi: Unexpected Leverages"
+assert htmlText.indexOf("Command Lines") > -1 : "NvidiaSmi: Unexpected Technology and protocols"
+assert htmlText.indexOf("<code>nvidia-smi</code>") > -1 : "NvidiaSmi: Unexpected criterion command line"

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageReferenceProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageReferenceProducer.java
@@ -437,7 +437,7 @@ public class ConnectorPageReferenceProducer {
 			yamlBuilder.append("            community: public # or probably something more secure");
 		}
 
-		if (technologies.contains(TechnologyType.OS_COMMAND)) {
+		if (technologies.contains(TechnologyType.COMMAND_LINES)) {
 			if (OsType.WINDOWS.getPossibleHostType().equals(hostType)) {
 				cli.append(" --wmi -u USER");
 				yamlBuilder.append(WMI_SECTION);

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java
@@ -26,7 +26,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Enumeration representing different technology types such as HTTP, IPMI, SNMP, WMI, WBEM, System Commands, etc.
+ * Enumeration representing different technology types such as HTTP, IPMI, SNMP, WMI, WBEM, Command Lines, etc.
  */
 @AllArgsConstructor
 public enum TechnologyType {
@@ -41,9 +41,9 @@ public enum TechnologyType {
 	IPMI("IPMI"),
 
 	/**
-	 * System Commands
+	 * Command Lines
 	 */
-	OS_COMMAND("System Commands"),
+	COMMAND_LINES("Command Lines"),
 
 	/**
 	 * Simple Network Management Protocol (SNMP)
@@ -75,7 +75,8 @@ public enum TechnologyType {
 	private static final Map<String, TechnologyType> TECHNOLOGY_TYPE_MAP = Map.of(
 		"http", HTTP,
 		"ipmi", IPMI,
-		"oscommand", OS_COMMAND,
+		"oscommand", COMMAND_LINES,
+		"commandline", COMMAND_LINES,
 		"snmptable", SNMP,
 		"snmpget", SNMP,
 		"wbem", WBEM,

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CommandLineCriterion.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CommandLineCriterion.java
@@ -27,19 +27,19 @@ import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Builder;
 
 /**
- * Represents a criterion for filtering based on an OS Command.
+ * Represents a criterion for filtering based on a command line.
  *
  * @see AbstractCriterion
  */
-public class OsCommandCriterion extends AbstractCriterion {
+public class CommandLineCriterion extends AbstractCriterion {
 
 	/**
-	 * Constructs OsCommandCriterion with the specified JSON criterion.
+	 * Constructs CommandLineCriterion with the specified JSON criterion.
 	 *
-	 * @param criterion The JSON criterion for OS Command.
+	 * @param criterion The JSON criterion for command line.
 	 */
 	@Builder
-	public OsCommandCriterion(final JsonNode criterion) {
+	public CommandLineCriterion(final JsonNode criterion) {
 		super(criterion);
 	}
 

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionFactory.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionFactory.java
@@ -55,7 +55,8 @@ public class CriterionFactory {
 		map.put("devicetype", CriterionFactory::newDeviceTypeCriterion);
 		map.put("http", CriterionFactory::newHttpCriterion);
 		map.put("ipmi", CriterionFactory::newIpmiCriterion);
-		map.put("oscommand", CriterionFactory::newOsCommandCriterion);
+		map.put("oscommand", CriterionFactory::newCommandLineCriterion);
+		map.put("commandline", CriterionFactory::newCommandLineCriterion);
 		map.put("process", CriterionFactory::newProcessCriterion);
 		map.put("productrequirements", CriterionFactory::newProductRequirementsCriterion);
 		map.put("service", CriterionFactory::newServiceCriterion);
@@ -98,13 +99,13 @@ public class CriterionFactory {
 	}
 
 	/**
-	 * Creates a new {@link OsCommandCriterion} instance based on the provided {@link JsonNode}.
+	 * Creates a new {@link CommandLineCriterion} instance based on the provided {@link JsonNode}.
 	 *
 	 * @param node The {@link JsonNode} containing criterion configuration.
-	 * @return A new {@link OsCommandCriterion} instance.
+	 * @return A new {@link CommandLineCriterion} instance.
 	 */
-	private static AbstractCriterion newOsCommandCriterion(final JsonNode node) {
-		return new OsCommandCriterion(node);
+	private static CommandLineCriterion newCommandLineCriterion(final JsonNode node) {
+		return new CommandLineCriterion(node);
 	}
 
 	/**
@@ -143,7 +144,7 @@ public class CriterionFactory {
 	 * @param node The {@link JsonNode} containing criterion configuration.
 	 * @return A new {@link SnmpGetCriterion} instance.
 	 */
-	private static AbstractSnmpCriterion newSnmpGetCriterion(final JsonNode node) {
+	private static SnmpGetCriterion newSnmpGetCriterion(final JsonNode node) {
 		return new SnmpGetCriterion(node);
 	}
 
@@ -163,7 +164,7 @@ public class CriterionFactory {
 	 * @param node The {@link JsonNode} containing criterion configuration.
 	 * @return A new {@link WbemCriterion} instance.
 	 */
-	private static AbstractWqlCriterion newWbemCriterion(final JsonNode node) {
+	private static WbemCriterion newWbemCriterion(final JsonNode node) {
 		return new WbemCriterion(node);
 	}
 

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionSinkProduceVisitor.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionSinkProduceVisitor.java
@@ -77,12 +77,13 @@ public class CriterionSinkProduceVisitor implements ICriterionVisitor {
 		String url = "";
 		// If both URL and Path fields aren't null, concatenate them
 		if (urlField != null && pathField != null) {
-			String.format(
-				"%s%s%s",
-				urlField,
-				urlField.endsWith("/") || pathField.startsWith("/") ? "" : "/",
-				urlField.endsWith("/") && pathField.startsWith("/") ? pathField.substring(1) : pathField
-			);
+			url =
+				String.format(
+					"%s%s%s",
+					urlField,
+					urlField.endsWith("/") || pathField.startsWith("/") ? "" : "/",
+					urlField.endsWith("/") && pathField.startsWith("/") ? pathField.substring(1) : pathField
+				);
 			// if Only URL field value is found, use it
 		} else if (urlField != null) {
 			url = urlField;
@@ -159,16 +160,16 @@ public class CriterionSinkProduceVisitor implements ICriterionVisitor {
 	}
 
 	@Override
-	public void visit(OsCommandCriterion osCommandCriterion) {
+	public void visit(CommandLineCriterion commandLineCriterion) {
 		// Command Line
-		String commandLine = osCommandCriterion.getCommandLineOrDefault("N/A");
+		String commandLine = commandLineCriterion.getCommandLineOrDefault("N/A");
 
 		// Remove mentions to sudo
 		commandLine = commandLine.replaceAll("%\\{SUDO:[a-zA-Z\\d/\\-_]+\\}", "");
 
 		sink.listItem();
 		sink.text("The command below succeeds on the ");
-		if (osCommandCriterion.isExecuteLocallyOrDefault(false)) {
+		if (commandLineCriterion.isExecuteLocallyOrDefault(false)) {
 			sink.bold();
 			sink.text("agent host");
 			sink.bold_();
@@ -179,7 +180,7 @@ public class CriterionSinkProduceVisitor implements ICriterionVisitor {
 		sink.listItem();
 		sink.rawText(String.format("Command: <code>%s</code>", SinkHelper.replaceWithHtmlCode(commandLine)));
 		sink.listItem_();
-		final String expectedResult = osCommandCriterion.getExpectedResult();
+		final String expectedResult = commandLineCriterion.getExpectedResult();
 		if (expectedResult != null) {
 			sink.listItem();
 			sink.rawText(

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/ICriterionVisitor.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/ICriterionVisitor.java
@@ -50,11 +50,11 @@ public interface ICriterionVisitor {
 	void visit(IpmiCriterion ipmiCriterion);
 
 	/**
-	 * Visits the specified OS Command criterion.
+	 * Visits the specified Command Line criterion.
 	 *
-	 * @param osCommandCriterion The OS Command criterion to visit.
+	 * @param commandLineCriterion The Command Line criterion to visit.
 	 */
-	void visit(OsCommandCriterion osCommandCriterion);
+	void visit(CommandLineCriterion commandLineCriterion);
 
 	/**
 	 * Visits the specified Process criterion.


### PR DESCRIPTION
* Renamed `OsCommandCriterion` to `CommandLineCriterion`.
* Updated `CriterionFactory` to handle `commandLine` criteria.
* Changed `TechnologyType` value from `OS_COMMAND` to `COMMAND_LINES`.
* Rebranded `System Commands` as `Command Lines`.
* Fixed missing `url` in `CriterionSinkProduceVisitor`.
* Corrected JavaDoc.
* Modified IT tests input file `NvidiaSmi.yaml`.
* Updated IT tests to check the newly generated command line technology.