### PR TITLE
Issue #47: Add a new column to indicate if a connector is enterprise

### DIFF
--- a/src/it/metricshub-connectors/pom.xml
+++ b/src/it/metricshub-connectors/pom.xml
@@ -53,7 +53,7 @@
 					<dependency>
 						<groupId>org.sentrysoftware.maven</groupId>
 						<artifactId>maven-skin-tools</artifactId>
-						<version>1.2.00</version>
+						<version>1.3.00</version>
 					</dependency>
 				</dependencies>
 

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/AbstractConnectorReport.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/AbstractConnectorReport.java
@@ -129,6 +129,8 @@ public abstract class AbstractConnectorReport extends AbstractMavenReport {
 					Files
 						.readAllLines(file)
 						.stream()
+						.map(String::trim)
+						.filter(line -> !line.isEmpty())
 						.map(filename -> filename.substring(0, filename.lastIndexOf('.')))
 						.collect(Collectors.toCollection(ArrayList::new));
 

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/ReferenceReport.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/ReferenceReport.java
@@ -85,20 +85,19 @@ public class ReferenceReport extends AbstractConnectorReport {
 		}
 
 		// Main page
-		produceMainPage(connectors);
+		produceMainPage();
 
 		// Connector pages
-		produceConnectorPages(connectors, connectorSubdirectory, buildSupersededMap(connectors));
+		produceConnectorPages(connectorSubdirectory, buildSupersededMap());
 	}
 
 	/**
 	 * Builds a map representing the superseded relationships between connectors.
 	 *
-	 * @param connectors A map of connector IDs to JsonNode objects representing connectors.
 	 * @return A map where each key is a connector ID that is superseded by one or more connectors,
 	 *         and the associated value is a list of connectors that supersede it.
 	 */
-	private Map<String, List<String>> buildSupersededMap(final Map<String, JsonNode> connectors) {
+	private Map<String, List<String>> buildSupersededMap() {
 		final Map<String, List<String>> supersededMap = new HashMap<>();
 
 		connectors.forEach((connectorId, connector) ->
@@ -115,16 +114,12 @@ public class ReferenceReport extends AbstractConnectorReport {
 	/**
 	 * Produces individual connector pages for the Maven report
 	 *
-	 * @param connectors            A map of connector IDs to their corresponding JSON nodes.
 	 * @param connectorSubdirectory The subdirectory where individual connector pages are located.
 	 * @param supersededMap         A map representing the superseded relationships among connectors.
 	 * @throws MavenReportException If an error occurs while producing the connector pages.
 	 */
-	private void produceConnectorPages(
-		final Map<String, JsonNode> connectors,
-		final File connectorSubdirectory,
-		final Map<String, List<String>> supersededMap
-	) throws MavenReportException {
+	private void produceConnectorPages(final File connectorSubdirectory, final Map<String, List<String>> supersededMap)
+		throws MavenReportException {
 		for (Entry<String, JsonNode> connectorEntry : connectors.entrySet()) {
 			final String connectorId = connectorEntry.getKey();
 			// Create a new sink!
@@ -149,13 +144,12 @@ public class ReferenceReport extends AbstractConnectorReport {
 
 	/**
 	 * Produces the main page for the Maven report
-	 *
-	 * @param connectors            A map of connector IDs to their corresponding JSON nodes.
 	 */
-	private void produceMainPage(final Map<String, JsonNode> connectors) throws MavenReportException {
+	private void produceMainPage() throws MavenReportException {
 		final Sink mainSink = getMainSink();
 
-		new MainPageReferenceProducer(CONNECTOR_SUBDIRECTORY_NAME, logger).produce(mainSink, connectors);
+		new MainPageReferenceProducer(CONNECTOR_SUBDIRECTORY_NAME, logger)
+			.produce(mainSink, connectors, enterpriseConnectorIds);
 	}
 
 	@Override

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/ReferenceReport.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/ReferenceReport.java
@@ -138,7 +138,7 @@ public class ReferenceReport extends AbstractConnectorReport {
 				.withConnector(connectorEntry.getValue())
 				.withLogger(logger)
 				.build()
-				.produce(sink, supersededMap);
+				.produce(sink, supersededMap, enterpriseConnectorIds);
 		}
 	}
 

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageReferenceProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageReferenceProducer.java
@@ -59,8 +59,11 @@ public class ConnectorPageReferenceProducer {
 	/**
 	 * Produces a page reference for the current connector and generates the corresponding sink for documentation output.
 	 *
-	 * @param sink          The sink used for generating content.
-	 * @param supersededMap Map of superseded connectors.
+	 * This method generates a table with connector information, adding a new column to indicate if a connector is an enterprise connector.
+	 *
+	 * @param sink                   The sink used for generating content.
+	 * @param supersededMap          Map of superseded connectors.
+	 * @param enterpriseConnectorIds List of IDs for enterprise connectors.
 	 */
 	public void produce(final Sink sink, final Map<String, List<String>> supersededMap, final List<String> enterpriseConnectorIds) {
 		Objects.requireNonNull(connectorId, () -> "connectorId cannot be null.");

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageReferenceProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageReferenceProducer.java
@@ -62,7 +62,7 @@ public class ConnectorPageReferenceProducer {
 	 * @param sink          The sink used for generating content.
 	 * @param supersededMap Map of superseded connectors.
 	 */
-	public void produce(final Sink sink, final Map<String, List<String>> supersededMap) {
+	public void produce(final Sink sink, final Map<String, List<String>> supersededMap, final List<String> enterpriseConnectorIds) {
 		Objects.requireNonNull(connectorId, () -> "connectorId cannot be null.");
 		Objects.requireNonNull(connector, () -> "connector cannot be null.");
 		Objects.requireNonNull(supersededMap, () -> "supersededMap cannot be null.");
@@ -95,6 +95,10 @@ public class ConnectorPageReferenceProducer {
 		sink.section1();
 		sink.sectionTitle1();
 		sink.text(displayName);
+		// If the connector is Enterprise
+		if (enterpriseConnectorIds.contains(connectorId)) {
+			sink.rawText(SinkHelper.bootstrapLabel("Enterprise", "metricshub-enterprise-label"));
+		}
 		sink.sectionTitle1_();
 
 		// Description

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/MainPageReferenceProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/MainPageReferenceProducer.java
@@ -21,8 +21,6 @@ package org.sentrysoftware.maven.metricshub.connector.producer;
  */
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.io.File;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/MainPageReferenceProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/MainPageReferenceProducer.java
@@ -21,12 +21,17 @@ package org.sentrysoftware.maven.metricshub.connector.producer;
  */
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.doxia.sink.SinkEventAttributes;
+import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.apache.maven.plugin.logging.Log;
 import org.sentrysoftware.maven.metricshub.connector.ReferenceReport;
 import org.sentrysoftware.maven.metricshub.connector.producer.model.common.OsType;
@@ -45,10 +50,15 @@ public class MainPageReferenceProducer {
 	/**
 	 * Produces the main page reference that lists all the connectors.
 	 *
-	 * @param mainSink     The main sink used for generating content.
-	 * @param connectors   The map of connector identifiers to their corresponding JsonNodes.
+	 * @param mainSink               The main sink used for generating content.
+	 * @param connectors             The map of connector identifiers to their corresponding JsonNodes.
+	 * @param enterpriseConnectorIds The enterprise connector identifiers.
 	 */
-	public void produce(final Sink mainSink, final Map<String, JsonNode> connectors) {
+	public void produce(
+		final Sink mainSink,
+		final Map<String, JsonNode> connectors,
+		final List<String> enterpriseConnectorIds
+	) {
 		Objects.requireNonNull(connectorSubdirectoryName, () -> "connectorSubdirectoryName cannot be null.");
 		Objects.requireNonNull(mainSink, () -> "mainSink cannot be null.");
 		Objects.requireNonNull(logger, () -> "logger cannot be null.");
@@ -93,6 +103,9 @@ public class MainPageReferenceProducer {
 		mainSink.tableHeaderCell_();
 		mainSink.tableHeaderCell(SinkHelper.setClass(BOOTSTRAP_MEDIUM_3_CLASS));
 		mainSink.text("Operating Systems");
+		mainSink.tableHeaderCell_();
+		mainSink.tableHeaderCell(SinkHelper.setClass(BOOTSTRAP_MEDIUM_3_CLASS));
+		mainSink.text("Enterprise");
 		mainSink.tableHeaderCell_();
 		mainSink.tableRow_();
 
@@ -141,6 +154,11 @@ public class MainPageReferenceProducer {
 
 				mainSink.tableCell();
 				mainSink.text(String.join(", ", OsType.mapToDisplayNames(connectorJsonNodeReader.getAppliesTo())));
+				mainSink.tableCell_();
+
+				SinkEventAttributes attributes = new SinkEventAttributeSet(SinkEventAttributes.ALIGN, "center");
+				mainSink.tableCell(attributes);
+				mainSink.text(enterpriseConnectorIds.contains(connectorId) ? "\u2713" : "");
 				mainSink.tableCell_();
 
 				mainSink.tableRow_();

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/SinkHelper.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/SinkHelper.java
@@ -127,8 +127,13 @@ public class SinkHelper {
 	 * @param content text of the badge.
 	 * @return the HTML code for this badge.
 	 */
-	public static String bootstrapBadge(@NonNull final String content) {
-		return String.format("<span class=\"badge badge-secondary\">%s</span>", content);
+	public static String bootstrapLabel(@NonNull final String content, String customClassname) {
+		if (customClassname == null) {
+			customClassname = "";
+		} else {
+			customClassname = customClassname.trim() + " ";
+		}
+		return String.format(" <span class=\"%slabel label-default\">%s</span>", customClassname, content);
 	}
 
 	/**

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/SinkHelper.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/SinkHelper.java
@@ -24,6 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
@@ -118,6 +119,16 @@ public class SinkHelper {
 			glyphIconName = iconName;
 		}
 		return String.format("<i class=\"glyphicon glyphicon-%s\" aria-hidden=\"true\"></i>", glyphIconName);
+	}
+
+	/**
+	 * Create a bootstrap badge with the following content.
+	 *
+	 * @param content text of the badge.
+	 * @return the HTML code for this badge.
+	 */
+	public static String bootstrapBadge(@NonNull final String content) {
+		return String.format("<span class=\"badge badge-secondary\">%s</span>", content);
 	}
 
 	/**


### PR DESCRIPTION

* Extracted the Enterprise Connectors Manifest to retrieve the Enterprise Connectors Ids.
* Added a Enterprise column on `Connector Reference` page to know if a connector is a CC or EC.
* Updated maven skin tools version
* Refactored many methods to exculde their parameters.
* Added an `Enterprise` label on each Enterprise `ConnectorPageReference` page.
* Tested on MetricsHub Enterprise Documentation.