### PR TITLE
Issue #57: All the storage examples are incorrect with type=linux

### DIFF
--- a/src/it/metricshub-connectors/src/main/connector/hardware/WinStorageSpaces/WinStorageSpaces.yaml
+++ b/src/it/metricshub-connectors/src/main/connector/hardware/WinStorageSpaces/WinStorageSpaces.yaml
@@ -11,6 +11,7 @@ connector:
     - remote
     - local
     appliesTo:
+    - Storage
     - NT
     supersedes:
     - WBEMGenDiskNT

--- a/src/it/metricshub-connectors/verify.groovy
+++ b/src/it/metricshub-connectors/verify.groovy
@@ -214,7 +214,7 @@ assert htmlText.indexOf("Technology and protocols:") > - 1 : "MIB2 'Technology a
 assert htmlText.indexOf("SNMP") > - 1 : "MIB2 SNMP protocol must be present"
 assert htmlText.indexOf('<h3 id="examples">Examples</h3>') > - 1 : "MIB2: Page must indicate 'Examples' as HTML H3 element"
 assert htmlText.indexOf('<h4 id="cli">CLI</h4>') > - 1 : "MIB2: Page must indicate 'CLI' as HTML H4 element"
-assert htmlText.indexOf("metricshub HOSTNAME -t management -c +MIB2 --snmp v2c --community public") > - 1 : "MIB2: Page must indicate the expected CLI example"
+assert htmlText.indexOf("metricshub HOSTNAME -t network -c +MIB2 --snmp v2c --community public") > - 1 : "MIB2: Page must indicate the expected CLI example"
 assert htmlText.indexOf('<h4 id="metricshub-yaml">metricshub.yaml</h4>') > - 1 : "MIB2: Page must indicate 'metricshub.yaml' as HTML H4 element"
 assert htmlText.indexOf("snmp:") > - 1 : "MIB2: 'snmp:' yaml section must be present"
 assert htmlText.indexOf("v2c") > - 1 : "MIB2: version 'v2c' must be present in the yaml configuration example"
@@ -248,3 +248,12 @@ assert htmlText.indexOf("Microsoft Windows, Linux") > -1 : "NvidiaSmi: Unexpecte
 assert htmlText.indexOf("NVIDIA drivers with NVIDIA-SMI support") > -1 : "NvidiaSmi: Unexpected Leverages"
 assert htmlText.indexOf("Command Lines") > -1 : "NvidiaSmi: Unexpected Technology and protocols"
 assert htmlText.indexOf("<code>nvidia-smi</code>") > -1 : "NvidiaSmi: Unexpected criterion command line"
+
+// WinStoreSpaces
+htmlText = new File(basedir, "target/site/connectors/winstoragespaces.html").text
+assert htmlText.indexOf("Any system") > -1 : "WinStoreSpaces: Unexpected Typical platform"
+assert htmlText.indexOf("Storage System, Microsoft Windows") > -1 : "WinStoreSpaces: Unexpected Operating Systems"
+assert htmlText.indexOf("Windows Storage Spaces") > -1 : "WinStoreSpaces: Unexpected Leverages"
+assert htmlText.indexOf("WMI/WinRM") > -1 : "WinStoreSpaces: Unexpected Technology and protocols"
+assert htmlText.indexOf("<code>root\\Microsoft\\Windows\\Storage</code>") > -1 : "WinStoreSpaces: Unexpected namespaces"
+assert htmlText.indexOf("metricshub HOSTNAME -t storage -c +WinStorageSpaces --wmi -u USER") > -1 : "WinStoreSpaces: Page must indicate the expected CLI example."

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -212,7 +212,7 @@ public class ConnectorPageProducer {
 		sink.section2_();
 
 		// MetricsHub Example
-		produceMetricsHubExamplesContent(sink, osList, technologies, sudoCommands);
+		produceMetricsHubExamplesContent(sink, appliesTo, technologies, sudoCommands);
 
 		// Detection criteria
 		sink.section2();
@@ -407,7 +407,7 @@ public class ConnectorPageProducer {
 		yamlBuilder.append("          host.name: <HOSTNAME> # Change with actual host name\n");
 		yamlBuilder.append("          host.type: ").append(hostType).append("\n");
 		yamlBuilder
-			.append("        selectConnectors: [ ")
+			.append("        connectors: [ +")
 			.append(connectorId)
 			.append(" ] # Optional, to load only this connector\n")
 			.append(PROTOCOLS_SECTION);


### PR DESCRIPTION
* Fixed `ConnectorPageProducer` to detect right device types.
* Renamed `selectedConnectors` to `connectors` in the YAML examples.

### Testing
------------------------------------
Now the resource types in the CLI/YAML as well as the selected connectors in the YAML configuration are correctly displayed.
![image](https://github.com/user-attachments/assets/d4f99b2a-6a6d-4630-a159-81f99f196aa5)
