### PR TITLE
Issue #59: Display the connector variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,7 @@
 			<!-- checkstyle -->
 			<plugin>
 				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.5.0</version>
 				<configuration>
 					<sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
 					<linkXref>true</linkXref>

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
@@ -75,6 +75,11 @@ public class ConnectorJsonNodeReader {
 		"^\\s*([^\\{]*)\\{.*(\\s*state\\s*=\\s*.*)\\}\\s*$"
 	);
 
+	/**
+	 * Defines a regular expression pattern for matching connector variables name.
+	 */
+	private static final Pattern CONNECTOR_VARIABLE_PATTERN = Pattern.compile("\\$\\{var::(.*?)\\}");
+
 	private final JsonNode connector;
 
 	/**
@@ -122,7 +127,7 @@ public class ConnectorJsonNodeReader {
 	public List<String> getSupersedes() {
 		final JsonNode detection = getDetection();
 		if (nonNull(detection)) {
-			final JsonNode supersedes = detection.get("supersedes");
+			final JsonNode supersedes = detection.get("supersedes"); // NOSONAR nonNull() is already called
 			return nodeToStringList(supersedes);
 		}
 		return Collections.emptyList();
@@ -136,7 +141,7 @@ public class ConnectorJsonNodeReader {
 	public List<String> getAppliesTo() {
 		final JsonNode detection = getDetection();
 		if (nonNull(detection)) {
-			final JsonNode appliesTo = detection.get("appliesTo");
+			final JsonNode appliesTo = detection.get("appliesTo"); // NOSONAR nonNull() is already called
 			return nodeToStringList(appliesTo);
 		}
 		return Collections.emptyList();
@@ -156,7 +161,7 @@ public class ConnectorJsonNodeReader {
 		final JsonNode criteria = getDetectionCriteria();
 
 		// If criteria information is not available or is not an array, return null
-		if (!nonNull(criteria) || !criteria.isArray()) {
+		if (!nonNull(criteria) || !criteria.isArray()) { // NOSONAR nonNull() is already called
 			return null;
 		}
 
@@ -196,7 +201,7 @@ public class ConnectorJsonNodeReader {
 			return null;
 		}
 
-		return detection.get("criteria");
+		return detection.get("criteria"); // NOSONAR nonNull() is already called
 	}
 
 	/**
@@ -308,7 +313,7 @@ public class ConnectorJsonNodeReader {
 	public Set<String> getConnectionTypes() {
 		final JsonNode detection = getDetection();
 		if (nonNull(detection)) {
-			final JsonNode connectionTypes = detection.get("connectionTypes");
+			final JsonNode connectionTypes = detection.get("connectionTypes"); // NOSONAR nonNull() is already called
 			return nodeToCaseInsensitiveSet(connectionTypes);
 		}
 		return Collections.emptySet();
@@ -339,7 +344,7 @@ public class ConnectorJsonNodeReader {
 	public boolean isAutoDetectionDisabled() {
 		final JsonNode detection = getDetection();
 		if (nonNull(detection)) {
-			final JsonNode disableAutoDetection = detection.get("disableAutoDetection");
+			final JsonNode disableAutoDetection = detection.get("disableAutoDetection"); // NOSONAR nonNull() is already called
 			if (nonNull(disableAutoDetection) && disableAutoDetection.isBoolean()) {
 				return disableAutoDetection.asBoolean();
 			}
@@ -355,7 +360,7 @@ public class ConnectorJsonNodeReader {
 	public String getOnLastResort() {
 		final JsonNode detection = getDetection();
 		if (nonNull(detection)) {
-			final JsonNode onLastResort = detection.get("onLastResort");
+			final JsonNode onLastResort = detection.get("onLastResort"); // NOSONAR nonNull() is already called
 			if (nonNull(onLastResort)) {
 				return onLastResort.asText();
 			}
@@ -371,7 +376,7 @@ public class ConnectorJsonNodeReader {
 	public List<JsonNode> getCriteria() {
 		final JsonNode detectionCriteria = getDetectionCriteria();
 
-		if (nonNull(detectionCriteria) && detectionCriteria.isArray()) {
+		if (nonNull(detectionCriteria) && detectionCriteria.isArray()) { // NOSONAR nonNull() is already called
 			return stream((ArrayNode) detectionCriteria).collect(Collectors.toList());
 		}
 
@@ -572,7 +577,7 @@ public class ConnectorJsonNodeReader {
 	public boolean hasBladeMonitorJob() {
 		final JsonNode monitors = getMonitors().orElse(null);
 		if (nonNull(monitors)) {
-			final JsonNode bladeMonitorJob = monitors.get("blade");
+			final JsonNode bladeMonitorJob = monitors.get("blade"); // NOSONAR nonNull() is already called
 			if (nonNull(bladeMonitorJob)) {
 				final JsonNode[] bladeJobs = getMonitorJobs(bladeMonitorJob);
 				for (JsonNode bladeJob : bladeJobs) {
@@ -603,7 +608,7 @@ public class ConnectorJsonNodeReader {
 	public List<String> getTags() {
 		JsonNode detection = getDetection();
 		if (nonNull(detection)) {
-			final JsonNode tagsNode = detection.get("tags");
+			final JsonNode tagsNode = detection.get("tags"); // NOSONAR nonNull() is already called
 			return nodeToStringList(tagsNode);
 		}
 		return Collections.emptyList();
@@ -617,11 +622,9 @@ public class ConnectorJsonNodeReader {
 	 */
 	public Set<String> getVariablesNames() {
 		final String stringConnector = connector.toString();
-		final String variableRegex = "\\$\\{var::(.*?)\\}";
 		final Set<String> variables = new HashSet<>();
 
-		final Pattern pattern = Pattern.compile(variableRegex);
-		final Matcher matcher = pattern.matcher(stringConnector);
+		final Matcher matcher = CONNECTOR_VARIABLE_PATTERN.matcher(stringConnector);
 
 		while (matcher.find()) {
 			variables.add(matcher.group(1));
@@ -641,19 +644,19 @@ public class ConnectorJsonNodeReader {
 
 		final Map<String, ConnectorDefaultVariable> defaultVariables = new HashMap<>();
 		if (nonNull(variablesNode)) {
-			variablesNode
+			variablesNode // NOSONAR nonNull() is already called
 				.fields()
 				.forEachRemaining(entry -> {
 					final String variableName = entry.getKey();
 					final JsonNode variableValue = entry.getValue();
 
-					final String description = variableValue.get("description").asText();
-					final String defaultValue = variableValue.get("defaultValue").asText();
+					final JsonNode description = variableValue.get("description");
+					final JsonNode defaultValue = variableValue.get("defaultValue");
 
 					// Create a ConnectorDefaultVariable object and put it into the map
 					final ConnectorDefaultVariable connectorDefaultVariable = new ConnectorDefaultVariable(
-						description,
-						defaultValue
+						nonNullTextOrDefault(description, null),
+						nonNullTextOrDefault(defaultValue, null)
 					);
 					defaultVariables.put(variableName, connectorDefaultVariable);
 				});

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -245,7 +245,7 @@ public class ConnectorPageProducer {
 		sink.section2_();
 
 		// MetricsHub Example
-		produceMetricsHubExamplesContent(sink, osList, technologies, sudoCommands);
+		produceMetricsHubExamplesContent(sink, osList, technologies, sudoCommands, connectorVariables);
 
 		// Detection criteria
 		sink.section2();
@@ -421,7 +421,8 @@ public class ConnectorPageProducer {
 		final Sink sink,
 		final List<String> osTypes,
 		final Set<TechnologyType> technologies,
-		final List<String> sudoCommands
+		final List<String> sudoCommands,
+		final Set<String> connectorVariables
 	) {
 		sink.section2();
 		sink.sectionTitle2();
@@ -515,6 +516,12 @@ public class ConnectorPageProducer {
 			appendYamlUsernameAndPassword(yamlBuilder);
 		}
 
+		// Connector variable
+		if (connectorVariables != null && !connectorVariables.isEmpty()) {
+			yamlBuilder.append("        variables:\n");
+			yamlBuilder.append(String.format("          %s: %s", connectorVariables.iterator().next(), "<VALUE>"));
+			yamlBuilder.append(" # Replace with desired value.");
+		}
 		// CLI
 		sink.section3();
 		sink.sectionTitle3();

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import lombok.Builder;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.plugin.logging.Log;
+import org.sentrysoftware.maven.metricshub.connector.producer.model.common.ConnectorDefaultVariable;
 import org.sentrysoftware.maven.metricshub.connector.producer.model.common.OpenTelemetryHardwareType;
 import org.sentrysoftware.maven.metricshub.connector.producer.model.common.OsType;
 import org.sentrysoftware.maven.metricshub.connector.producer.model.common.TechnologyType;
@@ -186,6 +187,38 @@ public class ConnectorPageProducer {
 		sink.text(technologies.stream().map(TechnologyType::getDisplayName).collect(Collectors.joining(", ")));
 		sink.bold_();
 		sink.paragraph_();
+
+		// Displaying connector variables list
+		final Set<String> connectorVariables = connectorJsonNodeReader.getVariablesNames();
+		final Map<String, ConnectorDefaultVariable> connectorDefaultVariables =
+			connectorJsonNodeReader.getDefaultVariables();
+		if (!connectorVariables.isEmpty()) {
+			sink.paragraph();
+			sink.text("Variables:");
+			sink.list();
+			for (final String variable : connectorVariables) {
+				sink.listItem();
+				sink.rawText(String.format("<code>%s</code>", variable));
+				sink.list();
+				sink.listItem();
+				final ConnectorDefaultVariable defaultVariable = connectorDefaultVariables.getOrDefault(
+					variable,
+					new ConnectorDefaultVariable("", "No default value.")
+				);
+				sink.text("description: ");
+				sink.text(defaultVariable.getDescription());
+				sink.listItem_();
+
+				sink.listItem();
+				sink.text("default value: ");
+				sink.text(defaultVariable.getDefaultValue());
+				sink.listItem_();
+				sink.list_();
+				sink.listItem_();
+			}
+			sink.list_();
+			sink.paragraph_();
+		}
 
 		// Sudo Commands?
 		final List<String> sudoCommands = connectorJsonNodeReader.getSudoCommands();

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -245,7 +245,7 @@ public class ConnectorPageProducer {
 		sink.section2_();
 
 		// MetricsHub Example
-		produceMetricsHubExamplesContent(sink, osList, technologies, sudoCommands, connectorVariables);
+		produceMetricsHubExamplesContent(sink, appliesTo, technologies, sudoCommands, connectorVariables);
 
 		// Detection criteria
 		sink.section2();
@@ -520,7 +520,7 @@ public class ConnectorPageProducer {
 		if (connectorVariables != null && !connectorVariables.isEmpty()) {
 			yamlBuilder.append("        variables:\n");
 			yamlBuilder.append(String.format("          %s: %s", connectorVariables.iterator().next(), "<VALUE>"));
-			yamlBuilder.append(" # Replace with desired value.");
+			yamlBuilder.append(" # Replace with desired value.\n");
 		}
 		// CLI
 		sink.section3();

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -199,21 +199,10 @@ public class ConnectorPageProducer {
 			for (final String variable : connectorVariables) {
 				sink.listItem();
 				sink.rawText(String.format("<code>%s</code>", variable));
-				sink.list();
-				sink.listItem();
-				final ConnectorDefaultVariable defaultVariable = connectorDefaultVariables.getOrDefault(
-					variable,
-					new ConnectorDefaultVariable("", "No default value.")
-				);
-				sink.text("description: ");
-				sink.text(defaultVariable.getDescription());
-				sink.listItem_();
-
-				sink.listItem();
-				sink.text("default value: ");
-				sink.text(defaultVariable.getDefaultValue());
-				sink.listItem_();
-				sink.list_();
+				final ConnectorDefaultVariable connectorDefaultVariable = connectorDefaultVariables.get(variable);
+				if (connectorDefaultVariable != null) {
+					produceVariableSection(sink, connectorDefaultVariables.get(variable));
+				}
 				sink.listItem_();
 			}
 			sink.list_();
@@ -519,8 +508,12 @@ public class ConnectorPageProducer {
 		// Connector variable
 		if (connectorVariables != null && !connectorVariables.isEmpty()) {
 			yamlBuilder.append("        variables:\n");
-			yamlBuilder.append(String.format("          %s: %s", connectorVariables.iterator().next(), "<VALUE>"));
-			yamlBuilder.append(" # Replace with desired value.\n");
+			connectorVariables
+				.iterator()
+				.forEachRemaining(variable -> {
+					yamlBuilder.append(String.format("          %s: %s", variable, "<VALUE>"));
+					yamlBuilder.append(" # Replace with desired value.\n");
+				});
 		}
 		// CLI
 		sink.section3();
@@ -697,5 +690,25 @@ public class ConnectorPageProducer {
 			SinkHelper.insertCodeBlock(sink, "bash", sudoersContent.toString());
 			sink.paragraph_();
 		}
+	}
+
+	/**
+	 * Produces a section of text for the connector variable, including its description and default value,
+	 * and writes it to the provided sink.
+	 *
+	 * @param sink            The sink used for generating content.
+	 * @param defaultVariable The variable containing the description and default value to be formatted and output.
+	 */
+	private void produceVariableSection(final Sink sink, ConnectorDefaultVariable defaultVariable) {
+		final String variableDescription = defaultVariable.getDescription();
+		final String variableDefaultValue = defaultVariable.getDefaultValue();
+
+		final String defaultDescriptionString = variableDescription != null
+			? String.format(": %s", variableDescription)
+			: "";
+		final String defaultValueString = variableDefaultValue != null
+			? String.format("(default: <code>%s</code>)", variableDefaultValue)
+			: "";
+		sink.rawText(String.format("%s %s", defaultDescriptionString, defaultValueString));
 	}
 }

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/ConnectorDefaultVariable.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/ConnectorDefaultVariable.java
@@ -1,0 +1,42 @@
+package org.sentrysoftware.maven.metricshub.connector.producer.model.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Connector Maven Plugin
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2023 Sentry Software
+ * ჻჻჻჻჻჻
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class ConnectorDefaultVariable {
+
+	/**
+	 * The default connector variable description.
+	 */
+	private String description;
+	/**
+	 * The default connector variable default value.
+	 */
+	private String defaultValue;
+}

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/ConnectorDefaultVariable.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/ConnectorDefaultVariable.java
@@ -1,10 +1,5 @@
 package org.sentrysoftware.maven.metricshub.connector.producer.model.common;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * MetricsHub Connector Maven Plugin
@@ -24,6 +19,11 @@ import lombok.NoArgsConstructor;
  * limitations under the License.
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
* Added a `variables` section under the `prerequisites` in the connectors pages to display the connector template variables, their description & their default value if available.
* Updated MetricsHub example content producer to add variables configuration example.
* Tested on metricshub-doc.

# Tests
## Default connector variables specified (description and defaultValue specified)
![image](https://github.com/user-attachments/assets/8cf51f77-f0f2-448c-a343-834f19e461bd)


## Default connector variables specified (description not specified)
![image](https://github.com/user-attachments/assets/65a10213-1e90-4568-94a1-520103968ab2)

## Default connector variables specified (defaultValue not specified)
![image](https://github.com/user-attachments/assets/70c7facf-3e0b-4ce9-9ccf-bfd704e694cf)

## Default connector variables not specified (variables are present).
![image](https://github.com/user-attachments/assets/5c98494f-d9d0-4bfe-bab6-e6df5259e554)

## MetricsHub.yaml example
![image](https://github.com/user-attachments/assets/d05a422e-7993-4498-892f-2cd8ea55b46b)


