### PR TITLE
Issue #58: add community connector GitHub link on each connector page

### DIFF
--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/parser/ConnectorLibraryParser.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/parser/ConnectorLibraryParser.java
@@ -51,7 +51,7 @@ public class ConnectorLibraryParser {
 
 		private final Path sourceDirectory;
 
-		public ConnectorFileVisitor(final Path sourceDirectory) {
+		ConnectorFileVisitor(final Path sourceDirectory) {
 			this.sourceDirectory = sourceDirectory;
 		}
 

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/parser/ConnectorLibraryParser.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/parser/ConnectorLibraryParser.java
@@ -23,6 +23,7 @@ package org.sentrysoftware.maven.metricshub.connector.parser;
 import static org.sentrysoftware.maven.metricshub.connector.Constants.YAML_OBJECT_MAPPER;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -48,6 +49,12 @@ public class ConnectorLibraryParser {
 		@Getter
 		private final Map<String, JsonNode> connectorsMap = new HashMap<>();
 
+		private final Path sourceDirectory;
+
+		public ConnectorFileVisitor(final Path sourceDirectory) {
+			this.sourceDirectory = sourceDirectory;
+		}
+
 		@Override
 		public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 			// Skip this path if it is a directory or not a YAML file
@@ -61,6 +68,8 @@ public class ConnectorLibraryParser {
 			}
 
 			final JsonNode connector = ConnectorParser.withNodeProcessor(file.getParent()).parse(file.toFile());
+
+			((ObjectNode) connector).put("relativePath", sourceDirectory.relativize(file).toString());
 
 			final Path fileNamePath = file.getFileName();
 
@@ -107,7 +116,7 @@ public class ConnectorLibraryParser {
 	 * @throws IOException if the file does not exist
 	 */
 	public Map<String, JsonNode> parse(@NonNull final Path sourceDirectory) throws IOException {
-		final ConnectorFileVisitor fileVisitor = new ConnectorFileVisitor();
+		final ConnectorFileVisitor fileVisitor = new ConnectorFileVisitor(sourceDirectory);
 
 		Files.walkFileTree(sourceDirectory, fileVisitor);
 

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
@@ -664,6 +664,12 @@ public class ConnectorJsonNodeReader {
 		return defaultVariables;
 	}
 
+	/**
+	 * Retrieves the relative path of the connector that was saved during parsing.
+	 * This path is used to generate a link to the connector's source code.
+	 *
+	 * @return The saved relative path as a string.
+	 */
 	public String getRelativePath() {
 		return connector.get("relativePath").asText();
 	}

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
@@ -663,4 +663,8 @@ public class ConnectorJsonNodeReader {
 		}
 		return defaultVariables;
 	}
+
+	public String getRelativePath() {
+		return connector.get("relativePath").asText();
+	}
 }

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -21,11 +21,13 @@ package org.sentrysoftware.maven.metricshub.connector.producer;
  */
 
 import static org.sentrysoftware.maven.metricshub.connector.ConnectorsDirectoryReport.CONNECTORS_DIRECTORY_OUTPUT_NAME;
+import static org.sentrysoftware.maven.metricshub.connector.Constants.TAG_SUBDIRECTORY_NAME;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.text.ChoiceFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -121,6 +123,26 @@ public class ConnectorPageProducer {
 		sink.paragraph_();
 
 		produceSupersedesContent(sink, supersededMap, connectorJsonNodeReader);
+
+		// Display the connector tags
+		final List<String> connectorTags = connectorJsonNodeReader.getTags();
+		sink.paragraph();
+		connectorTags
+			.stream()
+			.sorted(String.CASE_INSENSITIVE_ORDER)
+			.collect(Collectors.toCollection(LinkedHashSet::new))
+			.forEach(tag ->
+				sink.rawText(
+					SinkHelper.bootstrapLabel(
+						SinkHelper.hyperlinkRef(
+							String.format("%s/%s.html", TAG_SUBDIRECTORY_NAME, tag.toLowerCase().replace(" ", "-")),
+							tag
+						),
+						"metricshub-tag"
+					)
+				)
+			);
+		sink.paragraph_();
 
 		// The GitHub link will be generated only for community connectors
 		if (!enterpriseConnectorIds.contains(connectorId)) {

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -56,6 +56,7 @@ public class ConnectorPageProducer {
 	private final String connectorId;
 	private final JsonNode connector;
 	private final Log logger;
+	private String connectorDirectory;
 
 	/**
 	 * Produces a report page for the current connector and generates the corresponding sink for documentation output.
@@ -120,6 +121,15 @@ public class ConnectorPageProducer {
 		sink.paragraph_();
 
 		produceSupersedesContent(sink, supersededMap, connectorJsonNodeReader);
+
+		// The GitHub link will be generated only for community connectors
+		if (!enterpriseConnectorIds.contains(connectorId)) {
+			connectorDirectory = connectorJsonNodeReader.getRelativePath().replace("\\", "/");
+			// Add a link to the connector source.
+			sink.paragraph();
+			sink.rawText(SinkHelper.gitHubHyperlinkRef(connectorDirectory, "Source"));
+			sink.paragraph_();
+		}
 
 		// End of the second heading element
 		sink.section2_();

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/SinkHelper.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/SinkHelper.java
@@ -183,7 +183,7 @@ public class SinkHelper {
 	public static String gitHubHyperlinkRef(final String link, final String content) {
 		return String.format(
 			"" +
-			"<a href=\"https://github.com/sentrysoftware/metricshub-community-connectors/tree/main/src/main/connector/%s\" class=\"externalLink\" " +
+			"<a href=\"https://github.com/sentrysoftware/metricshub-community-connectors/tree/main/src/main/connector/%s\" " +
 			"<i class=\"fa-brands fa-github\">" +
 			"</i>" +
 			" %s" +

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/SinkHelper.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/SinkHelper.java
@@ -171,9 +171,25 @@ public class SinkHelper {
 	}
 
 	/**
-	 * Creates an HTML hyperlink reference with the given content
+	 * Creates an HTML hyperlink reference with the given content.
 	 */
 	public static String hyperlinkRef(final String link, final String content) {
 		return String.format("<a href=\"%s\">%s</a>", link, content);
+	}
+
+	/**
+	 * Creates an HTMP hyperlink reference with the given content and the specified classes.
+	 */
+	public static String gitHubHyperlinkRef(final String link, final String content) {
+		return String.format(
+			"" +
+			"<a href=\"https://github.com/sentrysoftware/metricshub-community-connectors/tree/main/src/main/connector/%s\" class=\"externalLink\" " +
+			"<i class=\"fa-brands fa-github\">" +
+			"</i>" +
+			" %s" +
+			"</a>",
+			link,
+			content
+		);
 	}
 }


### PR DESCRIPTION

* Added community connectors github link.
* Tested on the metricshub-doc & metricshub-enterprise doc. (on both windows & linux).

# Tests
- On a community connector
![image](https://github.com/user-attachments/assets/8f1e3d0a-2958-4262-8911-d9b5b7c66440)

- On an enterprise connector, the link won't be generated.