### PR TITLE
Issue #63: Display the new additional connectors configuration

### DIFF
--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -539,12 +539,14 @@ public class ConnectorPageProducer {
 
 		// Connector variable
 		if (connectorVariables != null && !connectorVariables.isEmpty()) {
+			
 			yamlBuilder.append("        additionalConnectors:\n");
-			yamlBuilder.append("          <ADDITIONAL-CONNECTOR-ID>:\n");
+			yamlBuilder.append("          " + connectorId);
+			yamlBuilder.append(": # Unique ID. Use 'uses' if different from the original connector ID\n");
 			yamlBuilder.append("            uses: " + connectorId);
-			yamlBuilder.append(" # Id of connector to use\n");
-			yamlBuilder.append("            force: true/false");
-			yamlBuilder.append(" # true by default\n");
+			yamlBuilder.append(" # Optional - Original ID if not in key\n");
+			yamlBuilder.append("            force: true");
+			yamlBuilder.append(" # Optional (default: true); false for auto-detection only\n");
 			yamlBuilder.append("            variables:\n");
 			connectorVariables
 				.iterator()

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -539,7 +539,6 @@ public class ConnectorPageProducer {
 
 		// Connector variable
 		if (connectorVariables != null && !connectorVariables.isEmpty()) {
-			
 			yamlBuilder.append("        additionalConnectors:\n");
 			yamlBuilder.append("          " + connectorId);
 			yamlBuilder.append(": # Unique ID. Use 'uses' if different from the original connector ID\n");

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -539,11 +539,17 @@ public class ConnectorPageProducer {
 
 		// Connector variable
 		if (connectorVariables != null && !connectorVariables.isEmpty()) {
-			yamlBuilder.append("        variables:\n");
+			yamlBuilder.append("        additionalConnectors:\n");
+			yamlBuilder.append("          <ADDITIONAL-CONNECTOR-ID>:\n");
+			yamlBuilder.append("            uses: " + connectorId);
+			yamlBuilder.append(" # Id of connector to use\n");
+			yamlBuilder.append("            force: true/false");
+			yamlBuilder.append(" # true by default\n");
+			yamlBuilder.append("            variables:\n");
 			connectorVariables
 				.iterator()
 				.forEachRemaining(variable -> {
-					yamlBuilder.append(String.format("          %s: %s", variable, "<VALUE>"));
+					yamlBuilder.append(String.format("              %s: %s", variable, "<VALUE>"));
 					yamlBuilder.append(" # Replace with desired value.\n");
 				});
 		}


### PR DESCRIPTION
* Updated the plugin to generate `additionalConnectors` section instead of `variables` which has been abandonned.
* Tested on both MetricsHub community & Enterprise documentations.

# Tests (WindowsProcess connector)
![image (4)](https://github.com/user-attachments/assets/3a564f0d-7f93-4dea-9139-59ecc5c1c493)

