### PR TITLE
Issue #66: Add `Enterprise` and `Community` tags on connectors

### DIFF
--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/ConnectorsDirectoryReport.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/ConnectorsDirectoryReport.java
@@ -235,7 +235,7 @@ public class ConnectorsDirectoryReport extends AbstractConnectorReport {
 				final JsonNode connector = connectorEntry.getValue();
 				final ConnectorJsonNodeReader reader = new ConnectorJsonNodeReader(connector);
 				return reader
-					.getTags()
+					.getAndCompleteTags(enterpriseConnectorIds.contains(connectorEntry.getKey()))
 					.stream()
 					.filter(tag -> !tag.isBlank())
 					.map(tag -> new AbstractMap.SimpleEntry<>(tag, connectorEntry));

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -618,7 +617,9 @@ public class ConnectorJsonNodeReader {
 		JsonNode detection = getDetection();
 		if (nonNull(detection)) {
 			final JsonNode tagsNode = detection.get("tags"); // NOSONAR nonNull() is already called
-			final ArrayNode tagsArrayNode = tagsNode != null && !tagsNode.isNull() ? (ArrayNode) tagsNode : JsonNodeFactory.instance.arrayNode();
+			final ArrayNode tagsArrayNode = tagsNode != null && !tagsNode.isNull()
+				? (ArrayNode) tagsNode
+				: JsonNodeFactory.instance.arrayNode();
 
 			tagsArrayNode.add(isEnterprise ? "enterprise" : "community");
 
@@ -635,8 +636,9 @@ public class ConnectorJsonNodeReader {
 	 */
 	public List<String> getTags() {
 		JsonNode detection = getDetection();
-		return nonNull(detection) ? nodeToStringList(detection.get("tags")) // NOSONAR nonNull() is already called
-				: Collections.emptyList();
+		return nonNull(detection)
+			? nodeToStringList(detection.get("tags")) // NOSONAR nonNull() is already called
+			: Collections.emptyList();
 	}
 
 	/**

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
@@ -27,6 +27,10 @@ import static org.sentrysoftware.maven.metricshub.connector.producer.JsonNodeHel
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -601,17 +605,38 @@ public class ConnectorJsonNodeReader {
 	}
 
 	/**
+	 * Retrieves and adds a specified tag to the detection JSON node's "tags" list.
+	 * <p>
+	 * Adds either "enterprise" or "community" to the "tags" field based on the {@code isEnterprise} parameter.
+	 * If the "tags" field is absent or null, it initializes a new array with the specified tag.
+	 * </p>
+	 *
+	 * @param isEnterprise {@code true} to add "enterprise" to the tags; {@code false} to add "community".
+	 * @return a list of tags as strings, including the added tag, or an empty list if the detection node is null.
+	 */
+	public List<String> getAndCompleteTags(final boolean isEnterprise) {
+		JsonNode detection = getDetection();
+		if (nonNull(detection)) {
+			final JsonNode tagsNode = detection.get("tags"); // NOSONAR nonNull() is already called
+			final ArrayNode tagsArrayNode = tagsNode != null && !tagsNode.isNull() ? (ArrayNode) tagsNode : JsonNodeFactory.instance.arrayNode();
+
+			tagsArrayNode.add(isEnterprise ? "enterprise" : "community");
+
+			((ObjectNode) detection).set("tags", tagsArrayNode);
+			return nodeToStringList(tagsArrayNode);
+		}
+		return Collections.emptyList();
+	}
+
+	/**
 	 * Retrieves a list of tags from the detection JSON node.
 	 *
 	 * @return a list of tags as strings, or an empty list if no tags are found.
 	 */
 	public List<String> getTags() {
 		JsonNode detection = getDetection();
-		if (nonNull(detection)) {
-			final JsonNode tagsNode = detection.get("tags"); // NOSONAR nonNull() is already called
-			return nodeToStringList(tagsNode);
-		}
-		return Collections.emptyList();
+		return nonNull(detection) ? nodeToStringList(detection.get("tags")) // NOSONAR nonNull() is already called
+				: Collections.emptyList();
 	}
 
 	/**

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorJsonNodeReader.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -106,10 +106,6 @@ public class ConnectorPageProducer {
 		sink.section1();
 		sink.sectionTitle1();
 		sink.text(displayName);
-		// If the connector is Enterprise
-		if (enterpriseConnectorIds.contains(connectorId)) {
-			sink.rawText(SinkHelper.bootstrapLabel("Enterprise", "metricshub-enterprise-label"));
-		}
 		sink.sectionTitle1_();
 
 		// Description


### PR DESCRIPTION
* Added programatically `Enterprise` or `Community` tags on all connectors.
* Added `Enterprise` and `Community` tags pages.
* Tested the changes on both MetricsHub community and Enterprise Docs.

# Tests
## Main page
![image](https://github.com/user-attachments/assets/bca6c83c-3558-4c96-b2c7-493923eddee0)
## Community tag page
![image](https://github.com/user-attachments/assets/22fce28f-9862-4e2f-b6e3-28014a86079f)
## Enterprise tag page
![image](https://github.com/user-attachments/assets/278638ab-b47c-4bb2-825e-196f6a108e8e)
## 1- An Enterprise connector without `enterprise` label (only with `enterprise`tag) 
![image](https://github.com/user-attachments/assets/fcc06b45-21ea-42a8-a078-5e6841531abf)
## 2- An Enterprise connector with both `enterprise` label and `enterprise`tag
![image](https://github.com/user-attachments/assets/350f80bf-ba52-42e6-9de7-5ef6a42336cd)

@bertysentry @NassimBtk which one do you prefer ?

