### PR TITLE
Issue #68:  Add the support for SQL connectors

### DIFF
--- a/src/it/metricshub-connectors/src/main/connector/database/Database/Database.yaml
+++ b/src/it/metricshub-connectors/src/main/connector/database/Database/Database.yaml
@@ -1,0 +1,21 @@
+metrics:
+  db.io:
+    description: The number of bytes sent or received to/from all clients.
+    type: Counter
+    unit: By
+  db.connections:
+    description: The number of connection attempts (successful or not) to the database.
+    type: Counter
+    unit: "{connection}"
+  db.client.connection.count:
+    description: The number of client connections to the database.
+    type: UpDownCounter
+    unit: "{connection}"
+  db.uptime:
+    description: The total number of seconds the server has been up.
+    type: Gauge
+    unit: s
+  db.queries:
+    description: The total number of statements executed by the server, including statements within stored programs but excluding `COM_PING` and `COM_STATISTICS` commands.
+    type: Counter
+    unit: "{statement}"

--- a/src/it/metricshub-connectors/src/main/connector/database/Database/Database.yaml
+++ b/src/it/metricshub-connectors/src/main/connector/database/Database/Database.yaml
@@ -16,6 +16,11 @@ metrics:
     type: Gauge
     unit: s
   db.queries:
-    description: The total number of statements executed by the server, including statements within stored programs but excluding `COM_PING` and `COM_STATISTICS` commands.
+    description: The total number of statements executed by the server.
     type: Counter
     unit: "{statement}"
+  db.tables:
+    description: The total number of tables in the database.
+    type: Gauge
+    unit: "{table}"
+

--- a/src/it/metricshub-connectors/src/main/connector/database/MySQL/MySQL.yaml
+++ b/src/it/metricshub-connectors/src/main/connector/database/MySQL/MySQL.yaml
@@ -297,8 +297,8 @@ monitors:
         attributes:
           id: $1
           db.version: $2
-          db.tables: $3
         metrics:
+          db.tables: $3
           db.aborted_connections{reason="client_disconnected"}: $4
           db.aborted_connections{reason="failed_attempt"}: $5
           db.io.{db.io.direction="received"}: $6

--- a/src/it/metricshub-connectors/src/main/connector/database/MySQL/MySQL.yaml
+++ b/src/it/metricshub-connectors/src/main/connector/database/MySQL/MySQL.yaml
@@ -1,0 +1,360 @@
+extends:
+- ../Database/Database
+connector:
+  displayName: MySQL
+  platforms: Any platform running MySQL
+  reliesOn : MySQL Database
+  information: Monitors performance and operational metrics for a MySQL database.
+  detection:
+    connectionTypes:
+    - remote
+    - local
+    appliesTo:
+    - windows
+    - linux
+    criteria:
+    - type: sql
+      query: SELECT @@version_comment REGEXP 'mysql' AS is_mysql;
+      expectedResult: 1
+      errorMessage: Not a MySQL Server
+    tags: [ linux, windows, database ]
+metrics:
+  db.aborted_connections:
+    description: The total number of aborted connections, categorized by reason (e.g., client disconnected or failed connection attempt).
+    type: Counter
+    unit: "{connection}"
+  db.connections.max_used:
+    description: The number of connections that have been in use simultaneously since the server started.
+    type: Gauge
+    unit: "{connection}"
+  db.connections.max_used.time:
+    description: The time at which Max_used_connections reached its current value.
+    type: Gauge
+    unit: s
+  db.query.execution_timeout:
+    description: The total number of SELECT statements where the execution timeout was exceeded or failed to be set.
+    type: Counter
+    unit: "{select_statement}"
+  db.buffer.pool.data.size:
+    description: The total number of bytes in the InnoDB buffer pool containing data.
+    type: Gauge
+    unit: By
+  db.innodb.buffer.pool.pages:
+    description: The number of pages in the InnoDB buffer pool.
+    type: Gauge
+    unit: "{page}"
+  db.innodb.buffer.pool.pages.read_ahead:
+    description: The number of pages read into the InnoDB buffer pool by the read-ahead background thread.
+    type: Counter
+    unit: "{page}"
+  db.buffer.pool.operations:
+    description: The number of logical read or write requests made to the InnoDB buffer pool.
+    type: Counter
+    unit: "{request}"
+  db.buffer.pool.disk_reads:
+    description: The number of logical reads that InnoDB could not satisfy from the buffer pool, and had to read directly from disk.
+    type: Counter
+    unit: "{read}"
+  db.innodb.operations:
+    description: The total number of data read or write operations in the InnoDB buffer pool.
+    type: Counter
+    unit: "{operation}"
+  db.innodb.io:
+    description: The amount of data read or written by InnoDB.
+    type: Counter
+    unit: "By"
+  db.innodb.io.pending:
+    description: The Current number of pending read or write operations in InnoDB.
+    type: Gauge
+    unit: "{operation}"
+  db.innodb.doublewrite.pages:
+    description: The number of pages that have been written to the doublewrite buffer.
+    type: Counter
+    unit: "{page}"
+  db.innodb.doublewrite.operations:
+    description: The number of doublewrite operations that have been performed.
+    type: Counter
+    unit: "{operation}"
+  db.innodb.files.open:
+    description: The current number of files that InnoDB holds open.
+    type: Gauge
+    unit: "{file}"
+  db.performance_schema.account_inserts:
+    description: The number of attempts to insert a row into the accounts table.
+    type: Counter
+    unit: "{insert_attempts}"
+  db.performance_schema.condition_instruments:
+    description: The number of condition instruments attempted to be created.
+    type: Counter
+    unit: "{cond_instruments}"
+  db.performance_schema.digest:
+    description: The number of digest instances instrumented in the `events_statements_summary_by_digest` table.
+    type: Counter
+    unit: "{digest_instances}"
+  db.performance_schema.file_instruments:
+    description: The number of file instruments attempted to be loaded.
+    type: Counter
+    unit: "{file_instrument}"
+  db.performance_schema.file_handles:
+    description: The number of file handles attempted to be opened.
+    type: Counter
+    unit: "{file_handles}"
+  db.performance_schema.file_instances:
+    description: The number of file instances attempted to be created.
+    type: Counter
+    unit: "{file_instance}"
+  db.performance_schema.hosts_inserts:
+    description: The number of attempts to insert a row into the hosts table.
+    type: Counter
+    unit: "{insert_attempts}"
+  db.performance_schema.index_statistics:
+    description: The number of indexes for which statistics were lost.
+    type: Counter
+    unit: "{index}"
+  db.performance_schema.memory_instruments:
+    description: Count of memory instruments attempted to be loaded.
+    type: Counter
+    unit: "{memory_instrument}"
+  db.performance_schema.metadata_lock:
+    description: The number of attempts to instrument metadata locks in the metadata_locks table.
+    type: Counter
+    unit: "{attempts}"
+  db.performance_schema.mutex_instruments:
+    description:  The total number of mutex instruments attempted to be loaded.
+    type: Counter
+    unit: "{mutex_instrument}"
+  db.performance_schema.mutex_instances:
+    description: The number of mutex instrument instances that could not be created.
+    type: Counter
+    unit: "{mutex_instance}"
+  db.innodb.row.lock.time:
+    description: The total time spent acquiring row locks for InnoDB tables.
+    type: Counter
+    unit: s
+  db.innodb.row.lock.time_avg:
+    description: The average time to acquire a row lock for InnoDB tables.
+    type: Gauge
+    unit: s
+  db.innodb.row.lock.time_max:
+    description: The maximum time to acquire a row lock for InnoDB tables.
+    type: Gauge
+    unit: s
+  db.innodb.row.lock.waits:
+    description: The number of times operations on InnoDB tables had to wait for a row lock.
+    type: Counter
+    unit: "{lock_waits}"
+  db.innodb.row.lock.current.waits:
+    description: The number of row locks currently waited for by operations on InnoDB tables.
+    type: Gauge
+    unit: "{current_lock}"
+  db.innodb.rows:
+    description: The total number of rows affected in InnoDB tables, categorized by operation type (insert, read, update, delete).
+    type: Counter
+    unit: "{row}"
+  db.threads:
+    description: "The number of database threads categorized by their state (cached, connected, created, or running)."
+    type: Gauge
+    unit: "{thread}"
+  db.uptime.since.flush_status:
+    description: The number of seconds since the most recent FLUSH STATUS statement.
+    type: Gauge
+    unit: s
+monitors:
+  mysql:
+    simple:
+      sources:
+        mysqlInfo:
+          type: sql
+          query: |
+            SELECT
+              DATABASE() AS db_namespace,
+              (SELECT VERSION()) AS version,
+              (SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE()) AS total_tables,
+              MAX(CASE WHEN VARIABLE_NAME = 'Aborted_clients' THEN VARIABLE_VALUE END) AS aborted_clients,
+              MAX(CASE WHEN VARIABLE_NAME = 'Aborted_connects' THEN VARIABLE_VALUE END) AS aborted_connects,
+              MAX(CASE WHEN VARIABLE_NAME = 'Bytes_received' THEN VARIABLE_VALUE END) AS bytes_received,
+              MAX(CASE WHEN VARIABLE_NAME = 'Bytes_sent' THEN VARIABLE_VALUE END) AS bytes_sent,
+              MAX(CASE WHEN VARIABLE_NAME = 'Connections' THEN VARIABLE_VALUE END) AS connections,
+              (SELECT COUNT(*) FROM information_schema.processlist WHERE command <> 'Sleep') AS connection_count,
+              MAX(CASE WHEN VARIABLE_NAME = 'Max_used_connections' THEN VARIABLE_VALUE END) AS max_used_connections,
+              MAX(CASE WHEN VARIABLE_NAME = 'Max_used_connections_time' THEN UNIX_TIMESTAMP(VARIABLE_VALUE) END) AS max_used_connections_time,
+              MAX(CASE WHEN VARIABLE_NAME = 'Max_execution_time_set_failed' THEN VARIABLE_VALUE END) AS max_execution_time_set_failed,
+              MAX(CASE WHEN VARIABLE_NAME = 'Max_execution_time_exceeded' THEN VARIABLE_VALUE END) AS max_execution_time_exceeded,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_bytes_data' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_bytes_data,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_pages_data' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_pages_data,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_pages_dirty' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_pages_dirty,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_pages_flushed' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_pages_flushed,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_pages_free' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_pages_free,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_read_ahead' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_read_ahead,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_read_ahead_evicted' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_read_ahead_evicted,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_read_ahead_rnd' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_read_ahead_rnd,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_read_requests' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_read_requests,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_write_requests' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_write_requests,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_buffer_pool_reads' THEN VARIABLE_VALUE END) AS innodb_buffer_pool_reads,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_data_reads' THEN VARIABLE_VALUE END) AS innodb_data_reads,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_data_writes' THEN VARIABLE_VALUE END) AS innodb_data_writes,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_data_read' THEN VARIABLE_VALUE END) AS innodb_data_read,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_data_written' THEN VARIABLE_VALUE END) AS innodb_data_written,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_data_pending_reads' THEN VARIABLE_VALUE END) AS innodb_data_pending_reads,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_data_pending_writes' THEN VARIABLE_VALUE END) AS innodb_data_pending_writes,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_dblwr_pages_written' THEN VARIABLE_VALUE END) AS innodb_dblwr_pages_written,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_num_open_files' THEN VARIABLE_VALUE END) AS innodb_num_open_files,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_accounts_lost' THEN VARIABLE_VALUE END) AS performance_schema_accounts_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_cond_classes_lost' THEN VARIABLE_VALUE END) AS performance_schema_cond_classes_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_digest_lost' THEN VARIABLE_VALUE END) AS performance_schema_digest_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_file_classes_lost' THEN VARIABLE_VALUE END) AS performance_schema_file_classes_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_file_handles_lost' THEN VARIABLE_VALUE END) AS performance_schema_file_handles_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_file_instances_lost' THEN VARIABLE_VALUE END) AS performance_schema_file_instances_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_hosts_lost' THEN VARIABLE_VALUE END) AS performance_schema_hosts_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_index_stat_lost' THEN VARIABLE_VALUE END) AS performance_schema_index_stat_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_locker_lost' THEN VARIABLE_VALUE END) AS performance_schema_locker_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_memory_classes_lost' THEN VARIABLE_VALUE END) AS performance_schema_memory_classes_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_metadata_lock_lost' THEN VARIABLE_VALUE END) AS performance_schema_metadata_lock_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_mutex_classes_lost' THEN VARIABLE_VALUE END) AS performance_schema_mutex_classes_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Performance_schema_mutex_instances_lost' THEN VARIABLE_VALUE END) AS performance_schema_mutex_instances_lost,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_row_lock_time' THEN VARIABLE_VALUE / 1000 END) AS innodb_row_lock_time,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_row_lock_time_avg' THEN VARIABLE_VALUE / 1000 END) AS innodb_row_lock_time_avg,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_row_lock_time_max' THEN VARIABLE_VALUE / 1000 END) AS innodb_row_lock_time_max,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_row_lock_waits' THEN VARIABLE_VALUE END) AS innodb_row_lock_waits,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_row_lock_current_waits' THEN VARIABLE_VALUE END) AS innodb_row_lock_current_waits,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_rows_deleted' THEN VARIABLE_VALUE END) AS innodb_rows_deleted,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_rows_inserted' THEN VARIABLE_VALUE END) AS innodb_rows_inserted,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_rows_read' THEN VARIABLE_VALUE END) AS innodb_rows_read,
+              MAX(CASE WHEN VARIABLE_NAME = 'Innodb_rows_updated' THEN VARIABLE_VALUE END) AS innodb_rows_updated,
+              MAX(CASE WHEN VARIABLE_NAME = 'Threads_cached' THEN VARIABLE_VALUE END) AS threads_cached,
+              MAX(CASE WHEN VARIABLE_NAME = 'Threads_connected' THEN VARIABLE_VALUE END) AS threads_connected,
+              MAX(CASE WHEN VARIABLE_NAME = 'Threads_created' THEN VARIABLE_VALUE END) AS threads_created,
+              MAX(CASE WHEN VARIABLE_NAME = 'Threads_running' THEN VARIABLE_VALUE END) AS threads_running,
+              MAX(CASE WHEN VARIABLE_NAME = 'Uptime' THEN VARIABLE_VALUE END) AS uptime,
+              MAX(CASE WHEN VARIABLE_NAME = 'Uptime_since_flush_status' THEN VARIABLE_VALUE END) AS uptime_since_flush_status,
+              MAX(CASE WHEN VARIABLE_NAME = 'Slow_queries' THEN VARIABLE_VALUE END) AS slow_queries,
+              MAX(CASE WHEN VARIABLE_NAME = 'Queries' THEN VARIABLE_VALUE END) AS queries
+            FROM
+              performance_schema.global_status
+            WHERE
+              VARIABLE_NAME IN (
+                'Aborted_clients',
+                'Aborted_connects',
+                'Bytes_received',
+                'Bytes_sent',
+                'Connections',
+                'Max_used_connections',
+                'Max_used_connections_time',
+                'Max_execution_time_set_failed',
+                'Max_execution_time_exceeded',
+                'Innodb_buffer_pool_bytes_data',
+                'Innodb_buffer_pool_pages_data',
+                'Innodb_buffer_pool_pages_dirty',
+                'Innodb_buffer_pool_pages_flushed',
+                'Innodb_buffer_pool_pages_free',
+                'Innodb_buffer_pool_read_ahead',
+                'Innodb_buffer_pool_read_ahead_evicted',
+                'Innodb_buffer_pool_read_ahead_rnd',
+                'Innodb_buffer_pool_read_requests',
+                'Innodb_buffer_pool_write_requests',
+                'Innodb_buffer_pool_reads',
+                'Innodb_data_reads',
+                'Innodb_data_writes',
+                'Innodb_data_read',
+                'Innodb_data_written',
+                'Innodb_data_pending_reads',
+                'Innodb_data_pending_writes',
+                'Innodb_dblwr_pages_written',
+                'Innodb_num_open_files',
+                'Performance_schema_accounts_lost',
+                'Performance_schema_cond_classes_lost',
+                'Performance_schema_digest_lost',
+                'Performance_schema_file_classes_lost',
+                'Performance_schema_file_handles_lost',
+                'Performance_schema_file_instances_lost',
+                'Performance_schema_hosts_lost',
+                'Performance_schema_index_stat_lost',
+                'Performance_schema_locker_lost',
+                'Performance_schema_memory_classes_lost',
+                'Performance_schema_metadata_lock_lost',
+                'Performance_schema_mutex_classes_lost',
+                'Performance_schema_mutex_instances_lost',
+                'Innodb_row_lock_time',
+                'Innodb_row_lock_time_avg',
+                'Innodb_row_lock_time_max',
+                'Innodb_row_lock_waits',
+                'Innodb_row_lock_current_waits',
+                'Innodb_rows_deleted',
+                'Innodb_rows_inserted',
+                'Innodb_rows_read',
+                'Innodb_rows_updated',
+                'Threads_cached',
+                'Threads_connected',
+                'Threads_created',
+                'Threads_running',
+                'Uptime',
+                'Uptime_since_flush_status',
+                'Slow_queries',
+                'Queries'
+              );
+      mapping:
+        source: ${source::mysqlInfo}
+        attributes:
+          id: $1
+          db.version: $2
+          db.tables: $3
+        metrics:
+          db.aborted_connections{reason="client_disconnected"}: $4
+          db.aborted_connections{reason="failed_attempt"}: $5
+          db.io.{db.io.direction="received"}: $6
+          db.io.{db.io.direction="sent"}: $7
+          db.connections: $8
+          db.client.connection.count{db.client.connection.state="used"}: $9
+          db.connections.max_used: $10
+          db.connections.max_used.time: $11
+          db.query.execution_timeout{execution_timeout.state="failed"}: $12
+          db.query.execution_timeout{execution_timeout.state="exceeded"}: $13
+          db.buffer.pool.data.size: $14
+          db.innodb.buffer.pool.pages{db.page.type="data"}: $15
+          db.innodb.buffer.pool.pages{db.page.type="dirty"}: $16
+          db.innodb.buffer.pool.pages{db.page.type="flushed"}: $17
+          db.innodb.buffer.pool.pages{db.page.type="free"}: $18
+          db.innodb.buffer.pool.pages.read_ahead: $19
+          db.innodb.buffer.pool.pages.read_ahead{db.pages.read_ahead.type="evicted"}: $20
+          db.innodb.buffer.pool.pages.read_ahead{db.pages.read_ahead.type="random"}: $21
+          db.buffer.pool.operations{db.operation.direction="read"}: $22
+          db.buffer.pool.operations{db.operation.direction="write"}: $23
+          db.buffer.pool.disk_reads: $24
+          db.innodb.operations{db.operation.direction="read"}: $25
+          db.innodb.operations{db.operation.direction="write"}: $26
+          db.innodb.io{db.io.direction="read"}: $27
+          db.innodb.io{db.io.direction="write"}: $28
+          db.innodb.io.pending{db.io.direction="read"}: $29
+          db.innodb.io.pending{db.io.direction="write"}: $30
+          db.innodb.page.{db.page.type="double_write"}: $31
+          db.innodb.operations{db.operations.direction="double_write"}: $32
+          db.innodb.open.files: $33
+          db.performance_schema.account_inserts{state="lost"}: $34
+          db.performance_schema.condition_instruments{state="lost"}: $35
+          db.performance_schema.digest{state ="lost"}: $36
+          db.performance_schema.file_instruments{state="lost"}: $37
+          db.performance_schema.file_handles{state ="lost"}: $38
+          db.performance_schema.file_instances{state="lost"}: $39
+          db.performance_schema.hosts_inserts{state="lost"}: $40
+          db.performance_schema.index_statistics: $41
+          db.performance_schema.memory_instruments{state ="lost"} : $42
+          db.performance_schema.metadata_lock{state ="lost"}: $43
+          db.performance_schema.mutex_instruments{state="lost"}: $44
+          db.performance_schema.mutex_instances{state ="lost"}: $45
+          db.innodb.row.lock.time: $46
+          db.innodb.row.lock.time_avg: $47
+          db.innodb.row.lock.time_max: $48
+          db.innodb.row.lock.waits: $49
+          db.innodb.row.lock.current.waits: $50
+          db.innodb.rows{db.operation.type="delete"}: $51
+          db.innodb.rows{db.operation.type="insert"}: $52
+          db.innodb.rows{db.operation.type="read"}: $53
+          db.innodb.rows{db.operation.type="update"}: $54
+          db.threads{db.thread.state="cashed"}: $55
+          db.threads{db.thread.state="connected"}: $56
+          db.threads{db.thread.state="created"}: $57
+          db.threads{db.thread.state="running"}: $58
+          db.uptime: $59
+          db.uptime.since.flush_status: $60
+          db.queries{db.thread.state="slow"}: $61
+          db.queries: $62

--- a/src/it/metricshub-connectors/src/site/site.xml
+++ b/src/it/metricshub-connectors/src/site/site.xml
@@ -12,7 +12,7 @@
 
 	<custom>
 		<noDefaultLinks>true</noDefaultLinks>
-		<keywords>metricshub, connector, hardware, system</keywords>
+		<keywords>metricshub, connector, hardware, system, database</keywords>
 		<bodyClass>custom-class</bodyClass>
 	</custom>
 
@@ -29,17 +29,9 @@
 
 		<menu name="User Documentation">
 			<item name="Getting Started" href="index.html" />
+			<item name="Connectors Directory" href="metricshub-connectors-directory.html"/>
 		</menu>
 
-		<menu name="MetricsHub Connectors">
-			<item name="Supported Platforms" href="platform-requirements.html " />
-		</menu>
-
-		<menu name="Reference">
-			<item name="Reference" href="metricshub-connector-reference.html"/>
-		</menu>
-
-		<menu ref="reports" />
 	</body>
 
 </project>

--- a/src/it/metricshub-connectors/verify.groovy
+++ b/src/it/metricshub-connectors/verify.groovy
@@ -31,6 +31,7 @@ assert htmlText.indexOf("WBEMGenDiskNT") > -1 : "metricshub-connectors-directory
 assert htmlText.indexOf("WBEMGenHBA") > -1 : "metricshub-connectors-directory: WBEMGenHBA must be listed"
 assert htmlText.indexOf("WBEMGenLUN") > -1 : "metricshub-connectors-directory: WBEMGenLUN must be listed"
 assert htmlText.indexOf("WBEMGenNetwork") > -1 : "metricshub-connectors-directory: WBEMGenNetwork must be listed"
+assert htmlText.indexOf("MySQL") > -1 : "metricshub-connectors-directory: MySQL must be listed"
 
 // Check generated reference files
 String directoryPath = 'target/site/connectors'
@@ -56,7 +57,8 @@ String [] fileNamesToCheck = [
 	'wbemgenhba.html',
 	'wbemgenlun.html',
 	'wbemgennetwork.html',
-	'winstoragespaces.html'
+	'winstoragespaces.html',
+	'mysql.html'
 ]
 
 fileNamesToCheck.each { fileName ->
@@ -74,6 +76,7 @@ String [] tagsFileNamesToCheck = [
 	'vm.html',
 	'hyper-v.html',
 	'hardware.html',
+	'database.html',
 ]
 
 String [] hardwareConnectors = [
@@ -257,3 +260,15 @@ assert htmlText.indexOf("Windows Storage Spaces") > -1 : "WinStoreSpaces: Unexpe
 assert htmlText.indexOf("WMI/WinRM") > -1 : "WinStoreSpaces: Unexpected Technology and protocols"
 assert htmlText.indexOf("<code>root\\Microsoft\\Windows\\Storage</code>") > -1 : "WinStoreSpaces: Unexpected namespaces"
 assert htmlText.indexOf("metricshub HOSTNAME -t storage -c +WinStorageSpaces --wmi -u USER") > -1 : "WinStoreSpaces: Page must indicate the expected CLI example."
+
+// MySQL
+htmlText = new File(basedir, "target/site/connectors/mysql.html").text
+assert htmlText.indexOf("Any platform running MySQL") > -1 : "MySQL: Unexpected Typical platform"
+assert htmlText.indexOf("Microsoft Windows, Linux") > -1 : "MySQL: Unexpected Operating Systems"
+assert htmlText.indexOf("MySQL Database") > -1 : "MySQL: Unexpected Leverages"
+assert htmlText.indexOf("SQL/JDBC") > -1 : "MySQL: Unexpected Technology and protocols"
+assert htmlText.indexOf("metricshub HOSTNAME -t win -c +MySQL --jdbc -u USER --jdbc-url URL") > -1 : "MySQL: Page must indicate the expected CLI example."
+assert htmlText.indexOf("<code>SELECT @@version_comment REGEXP 'mysql' AS is_mysql;</code>") > -1 : "MySQL: Page must indicate the activation criterion."
+assert htmlText.indexOf("Expected Result:") > -1 : "MySQL: Page must indicate the Expected Result message."
+assert htmlText.indexOf("<code>1</code>") > -1 : "MySQL: Page must indicate the expected result value."
+assert htmlText.indexOf('<h3 id="metrics">Metrics</h3>') > - 1 : "MySQL: Page must indicate 'Metrics' as HTML H3 element"

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/AbstractPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/AbstractPageProducer.java
@@ -148,7 +148,7 @@ public abstract class AbstractPageProducer {
 				sink.tableCell();
 				final Set<TechnologyType> technologies = connectorJsonNodeReader.getTechnologies();
 				for (final TechnologyType technology : technologies) {
-					sink.text(technology.toString());
+					sink.text(technology.getDisplayName());
 					sink.lineBreak();
 				}
 

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -533,6 +533,16 @@ public class ConnectorPageProducer {
 			appendYamlUsernameAndPassword(yamlBuilder);
 		}
 
+		if (technologies.contains(TechnologyType.SQL)) {
+		    cli.append(" --jdbc -u USER --jdbc-url URL");
+		    yamlBuilder.append("          jdbc:\n");
+		    yamlBuilder.append("            port: <PORT>\n");
+		    yamlBuilder.append("            database: <DB_NAME>\n");
+		    yamlBuilder.append("            type: <type>\n");
+		    yamlBuilder.append("            url: <URL>\n");
+            appendYamlUsernameAndPassword(yamlBuilder);
+		}
+
 		// Connector variable
 		if (connectorVariables != null && !connectorVariables.isEmpty()) {
 			yamlBuilder.append("        additionalConnectors:\n");

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -540,7 +540,7 @@ public class ConnectorPageProducer {
 		    yamlBuilder.append("            database: <DB_NAME>\n");
 		    yamlBuilder.append("            type: <type>\n");
 		    yamlBuilder.append("            url: <URL>\n");
-            appendYamlUsernameAndPassword(yamlBuilder);
+		    appendYamlUsernameAndPassword(yamlBuilder);
 		}
 
 		// Connector variable

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -534,13 +534,13 @@ public class ConnectorPageProducer {
 		}
 
 		if (technologies.contains(TechnologyType.SQL)) {
-		    cli.append(" --jdbc -u USER --jdbc-url URL");
-		    yamlBuilder.append("          jdbc:\n");
-		    yamlBuilder.append("            port: <PORT>\n");
-		    yamlBuilder.append("            database: <DB_NAME>\n");
-		    yamlBuilder.append("            type: <type>\n");
-		    yamlBuilder.append("            url: <URL>\n");
-		    appendYamlUsernameAndPassword(yamlBuilder);
+			cli.append(" --jdbc -u USER --jdbc-url URL");
+			yamlBuilder.append("          jdbc:\n");
+			yamlBuilder.append("            port: <PORT>\n");
+			yamlBuilder.append("            database: <DB_NAME>\n");
+			yamlBuilder.append("            type: <type>\n");
+			yamlBuilder.append("            url: <URL>\n");
+			appendYamlUsernameAndPassword(yamlBuilder);
 		}
 
 		// Connector variable

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/MainPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/MainPageProducer.java
@@ -58,6 +58,7 @@ public class MainPageProducer extends AbstractPageProducer {
 	 * @param mainSink               The main sink used for generating content.
 	 * @param connectors             The map of connector identifiers to their corresponding JsonNodes.
 	 * @param enterpriseConnectorIds The enterprise connector identifiers.
+	 * @param connectorTags          The set of connector tags.
 	 */
 	public void produce(
 		final Sink mainSink,

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/SinkHelper.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/SinkHelper.java
@@ -125,6 +125,7 @@ public class SinkHelper {
 	 * Create a bootstrap badge with the following content.
 	 *
 	 * @param content text of the badge.
+	 * @param customClassname custom class name to apply to the badge.
 	 * @return the HTML code for this badge.
 	 */
 	public static String bootstrapLabel(@NonNull final String content, String customClassname) {
@@ -172,13 +173,21 @@ public class SinkHelper {
 
 	/**
 	 * Creates an HTML hyperlink reference with the given content.
+	 *
+	 * @param link the URL to which the hyperlink points.
+	 * @param content the text to display as the clickable hyperlink.
+	 * @return a string containing the HTML code for the hyperlink
 	 */
 	public static String hyperlinkRef(final String link, final String content) {
 		return String.format("<a href=\"%s\">%s</a>", link, content);
 	}
 
 	/**
-	 * Creates an HTMP hyperlink reference with the given content and the specified classes.
+	 * Creates an HTML hyperlink reference with the given content.
+	 *
+	 * @param link the path in the `connector` directory.
+	 * @param content the text to display as the hyperlink.
+	 * @return string containing the HTML code for the hyperlink.
 	 */
 	public static String gitHubHyperlinkRef(final String link, final String content) {
 		return String.format(

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java
@@ -61,9 +61,9 @@ public enum TechnologyType {
 	WMI("WMI/WinRM"),
 
 	/**
-	 * SQL
+	 * SQL through JDBC
 	 */
-	SQL("SQL");
+	SQL("SQL/JDBC");
 
 	@Getter
 	private String displayName;

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java
@@ -58,7 +58,12 @@ public enum TechnologyType {
 	/**
 	 * Windows Management Instrumentation (WMI) / Windows Remote Management (WinRM)
 	 */
-	WMI("WMI/WinRM");
+	WMI("WMI/WinRM"),
+
+	/**
+     * SQL
+     */
+	SQL("SQL");
 
 	@Getter
 	private String displayName;
@@ -80,7 +85,8 @@ public enum TechnologyType {
 		"snmptable", SNMP,
 		"snmpget", SNMP,
 		"wbem", WBEM,
-		"wmi", WMI
+		"wmi", WMI,
+		"sql", SQL
 	);
 
 	// @formatter:on

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java
@@ -61,8 +61,8 @@ public enum TechnologyType {
 	WMI("WMI/WinRM"),
 
 	/**
-     * SQL
-     */
+	 * SQL
+	 */
 	SQL("SQL");
 
 	@Getter

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionFactory.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionFactory.java
@@ -64,6 +64,7 @@ public class CriterionFactory {
 		map.put("snmpgetnext", CriterionFactory::newSnmpGetNextCriterion);
 		map.put("wbem", CriterionFactory::newWbemCriterion);
 		map.put("wmi", CriterionFactory::newWmiCriterion);
+		map.put("sql", CriterionFactory::newSqlCriterion);
 
 		CRITERION_FACTORY_MAP = Collections.unmodifiableMap(map);
 	}
@@ -176,6 +177,16 @@ public class CriterionFactory {
 	 */
 	private static WmiCriterion newWmiCriterion(final JsonNode node) {
 		return new WmiCriterion(node);
+	}
+
+	/**
+	 * Creates a new {@link SqlCriterion} instance based on the provided {@link JsonNode}.
+	 *
+	 * @param node The {@link JsonNode} containing criterion configuration.
+	 * @return A new {@link SqlCriterion} instance.
+	 */
+	private static SqlCriterion newSqlCriterion(final JsonNode node) {
+		return new SqlCriterion(node);
 	}
 
 	/**

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionSinkProduceVisitor.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionSinkProduceVisitor.java
@@ -320,4 +320,32 @@ public class CriterionSinkProduceVisitor implements ICriterionVisitor {
 	public void visit(WmiCriterion wmiCriterion) {
 		buildWqlSink(wmiCriterion);
 	}
+
+	@Override
+	public void visit(final SqlCriterion sqlCriterion) {
+		// SQL
+	    sink.listItem();
+	    sink.text("The ");
+        sink.bold();
+		sink.text("SQL query");
+		sink.bold_();
+        sink.text(" below succeeds on the monitored database:");
+	    sink.list();
+		sink.list();
+		sink.listItem();
+		sink.rawText(String.format("SQL Query: <code>%s</code>", SinkHelper.replaceWithHtmlCode(sqlCriterion.getQuery())));
+		sink.listItem_();
+
+	    final String expectedResult = sqlCriterion.getExpectedResult();
+	    if (expectedResult != null) {
+	        sink.listItem();
+	        sink.rawText(String.format("Expected Result: <code>%s</code>", SinkHelper.replaceWithHtmlCode(expectedResult)));
+	        sink.listItem_();
+	    }
+
+	    // End the SQL criteria list
+	    sink.list_();
+	    sink.listItem_();
+	}
+
 }

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionSinkProduceVisitor.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionSinkProduceVisitor.java
@@ -324,13 +324,13 @@ public class CriterionSinkProduceVisitor implements ICriterionVisitor {
 	@Override
 	public void visit(final SqlCriterion sqlCriterion) {
 		// SQL
-	    sink.listItem();
-	    sink.text("The ");
-        sink.bold();
+		sink.listItem();
+		sink.text("The ");
+		sink.bold();
 		sink.text("SQL query");
 		sink.bold_();
-        sink.text(" below succeeds on the monitored database:");
-	    sink.list();
+		sink.text(" below succeeds on the monitored database:");
+		sink.list();
 		sink.list();
 		sink.listItem();
 		sink.rawText(String.format("SQL Query: <code>%s</code>", SinkHelper.replaceWithHtmlCode(sqlCriterion.getQuery())));

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionSinkProduceVisitor.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionSinkProduceVisitor.java
@@ -336,16 +336,15 @@ public class CriterionSinkProduceVisitor implements ICriterionVisitor {
 		sink.rawText(String.format("SQL Query: <code>%s</code>", SinkHelper.replaceWithHtmlCode(sqlCriterion.getQuery())));
 		sink.listItem_();
 
-	    final String expectedResult = sqlCriterion.getExpectedResult();
-	    if (expectedResult != null) {
-	        sink.listItem();
-	        sink.rawText(String.format("Expected Result: <code>%s</code>", SinkHelper.replaceWithHtmlCode(expectedResult)));
-	        sink.listItem_();
-	    }
+		final String expectedResult = sqlCriterion.getExpectedResult();
+		if (expectedResult != null) {
+			sink.listItem();
+			sink.rawText(String.format("Expected Result: <code>%s</code>", SinkHelper.replaceWithHtmlCode(expectedResult)));
+			sink.listItem_();
+		}
 
-	    // End the SQL criteria list
-	    sink.list_();
-	    sink.listItem_();
+		// End the SQL criteria list
+		sink.list_();
+		sink.listItem_();
 	}
-
 }

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/ICriterionVisitor.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/ICriterionVisitor.java
@@ -104,4 +104,11 @@ public interface ICriterionVisitor {
 	 * @param wmiCriterion The WMI criterion to visit.
 	 */
 	void visit(WmiCriterion wmiCriterion);
+
+	/**
+	 * Visits the specified SQL criterion.
+	 *
+	 * @param sqlCriterion The SQL criterion to visit.
+	 */
+	void visit(SqlCriterion sqlCriterion);
 }

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/SqlCriterion.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/SqlCriterion.java
@@ -1,4 +1,6 @@
-package org.sentrysoftware.maven.metricshub.connector.producer.model.common;
+package org.sentrysoftware.maven.metricshub.connector.producer.model.criteria;
+
+import static org.sentrysoftware.maven.metricshub.connector.producer.JsonNodeHelper.nonNullTextOrDefault;
 
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -20,26 +22,38 @@ package org.sentrysoftware.maven.metricshub.connector.producer.model.common;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
- * Represents a default variable for a connector.
+ * Represents a criterion for filtering based on a SQL query.
+ *
+ * @see AbstractCriterion
  */
-@NoArgsConstructor
-@AllArgsConstructor
-@Data
-@Builder
-public class ConnectorDefaultVariable {
+public class SqlCriterion extends AbstractCriterion {
 
 	/**
-	 * The default connector variable description.
+	 * Constructs SqlCriterion with the specified JSON criterion.
+	 *
+	 * @param criterion The JSON criterion for SQL check.
 	 */
-	private String description;
+	@Builder
+	public SqlCriterion(final JsonNode criterion) {
+		super(criterion);
+	}
+
 	/**
-	 * The default connector variable default value.
+	 * Gets the query from the current SQL criterion, or {@code null} if not present.
+	 *
+	 * @return The query from the criterion, or {@code null} if not present.
 	 */
-	private String defaultValue;
+	public String getQuery() {
+		return nonNullTextOrDefault(criterion.get("query"), null);
+	}
+
+	@Override
+	public void accept(ICriterionVisitor visitor) {
+		visitor.visit(this);
+	}
+
 }

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/SqlCriterion.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/SqlCriterion.java
@@ -1,7 +1,5 @@
 package org.sentrysoftware.maven.metricshub.connector.producer.model.criteria;
 
-import static org.sentrysoftware.maven.metricshub.connector.producer.JsonNodeHelper.nonNullTextOrDefault;
-
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * MetricsHub Connector Maven Plugin
@@ -21,6 +19,8 @@ import static org.sentrysoftware.maven.metricshub.connector.producer.JsonNodeHel
  * limitations under the License.
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
+
+import static org.sentrysoftware.maven.metricshub.connector.producer.JsonNodeHelper.nonNullTextOrDefault;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Builder;

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/SqlCriterion.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/SqlCriterion.java
@@ -55,5 +55,4 @@ public class SqlCriterion extends AbstractCriterion {
 	public void accept(ICriterionVisitor visitor) {
 		visitor.visit(this);
 	}
-
 }


### PR DESCRIPTION
This pull request introduces the SQL technology type to the MetricsHub connector and adds support for SQL criteria. The most important changes include updates to the `TechnologyType` enum, the addition of the `SqlCriterion` class, and modifications to the visitor pattern to handle SQL criteria.

### SQL Technology Integration:

* [`src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java`](diffhunk://#diff-0dd79ae9198afb2856eb1b55af21d3d5f1f9f5f2f6fccda9ffdb1869e547d594L61-R66): Added the `SQL` technology type to the `TechnologyType` enum and updated the mapping. [[1]](diffhunk://#diff-0dd79ae9198afb2856eb1b55af21d3d5f1f9f5f2f6fccda9ffdb1869e547d594L61-R66) [[2]](diffhunk://#diff-0dd79ae9198afb2856eb1b55af21d3d5f1f9f5f2f6fccda9ffdb1869e547d594L83-R89)

### SQL Criterion Support:

* [`src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/SqlCriterion.java`](diffhunk://#diff-74b824f6be2a18ad99467974beda717f26edbf625e76be5dcf98edf24a1a46ecR1-R59): Introduced the `SqlCriterion` class to represent SQL-based criteria.
* [`src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionFactory.java`](diffhunk://#diff-fa8accdb1962cfd81526ad22e8174521c964a282e7f1bacd8765d253e3a7a47aR67): Added a method to create `SqlCriterion` instances and updated the factory map. [[1]](diffhunk://#diff-fa8accdb1962cfd81526ad22e8174521c964a282e7f1bacd8765d253e3a7a47aR67) [[2]](diffhunk://#diff-fa8accdb1962cfd81526ad22e8174521c964a282e7f1bacd8765d253e3a7a47aR182-R191)
* [`src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/ICriterionVisitor.java`](diffhunk://#diff-5bf06ecfdf3b7bbf30d3670fe6968c22bc9273f85068661f01262016e70fdff5R107-R113): Updated the visitor interface to include a method for visiting `SqlCriterion` instances.
* [`src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/criteria/CriterionSinkProduceVisitor.java`](diffhunk://#diff-4a9b50f4ab18061083eeae96e59e9a1c3f41bdbf4f5538cadcfa4f61d4dd5f0eR323-R350): Implemented the visitor method to handle `SqlCriterion` instances and generate the corresponding sink content.

### Additional Enhancements:

* [`src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java`](diffhunk://#diff-e54c18ed97a6cf12d66d7c397c572aff571ad7f5b9ff39fb00bfeda6e91a09f6R536-R545): Added logic to handle SQL technology in the `produceMetricsHubExamplesContent` method.
* [`src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/ConnectorDefaultVariable.java`](diffhunk://#diff-ab4d7fa590528058f183769ee8cfbacf46bd01a63a117f800f453aaf245f36a1R28-R30): Added a Javadoc comment to describe the class.

## Tested: 
![Capture d'écran 2024-11-27 095226](https://github.com/user-attachments/assets/3e957fa6-51dd-42f4-8855-59706d922f0b)


