### PR TITLE
Issue #71: Display platform tiles in the connectors directory

### DIFF
--- a/src/it/metricshub-connectors/src/site/resources/css/site.css
+++ b/src/it/metricshub-connectors/src/site/resources/css/site.css
@@ -68,15 +68,10 @@
     justify-content: center;
 }
 
-.custom-class .platform-tile .platform-connectors {
-    font-size: 14px;
-    margin-bottom: 15px;
-    color: #333;
-    text-align: center;
-    min-height: 30px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.custom-class .platform-tile .platform-title .connectors-badge {
+    margin-top: 0px;
+    padding-left: 10px;
+    padding-bottom: 5px;
 }
 
 .custom-class .platform-tile .platform-icon {
@@ -86,7 +81,7 @@
     background-position: center;
 }
 
-.custom-class .platform-tile .platform-badges {
+.custom-class .platform-tile .platform-labels {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -95,9 +90,9 @@
     width: 100%;
 }
 
-.custom-class .platform-tile .badge {
+.custom-class .platform-tile .badge,
+.custom-class .platform-tile .label  {
     font-size: 10px;
-    border-radius: 10px;
     padding: 5px 10px;
     text-align: center;
     white-space: nowrap;

--- a/src/it/metricshub-connectors/verify.groovy
+++ b/src/it/metricshub-connectors/verify.groovy
@@ -252,7 +252,7 @@ htmlText = new File(basedir, "target/site/connectors/nvidiasmi.html").text
 assert htmlText.indexOf("Nvidia") > -1 : "NvidiaSmi: Unexpected Typical platform"
 assert htmlText.indexOf("Microsoft Windows, Linux") > -1 : "NvidiaSmi: Unexpected Operating Systems"
 assert htmlText.indexOf("NVIDIA drivers with NVIDIA-SMI support") > -1 : "NvidiaSmi: Unexpected Leverages"
-assert htmlText.indexOf("Command Lines") > -1 : "NvidiaSmi: Unexpected Technology and protocols"
+assert htmlText.indexOf("Commands") > -1 : "NvidiaSmi: Unexpected Technology and protocols"
 assert htmlText.indexOf("<code>nvidia-smi</code>") > -1 : "NvidiaSmi: Unexpected criterion command line"
 
 // WinStoreSpaces
@@ -313,19 +313,22 @@ platforms.each { platform ->
 }
 
 // Additional checks classes
-assert directoryHtmlText.indexOf("class=\"connectors-badge badge\"") > -1 : "connectors-badge class must be present in metricshub-connectors-directory.html"
-assert directoryHtmlText.indexOf("class=\"technology-badge badge\"") > -1 : "technology-badge class must be present in metricshub-connectors-directory.html"
+assert directoryHtmlText.indexOf("class=\"connectors-badge\"") > -1 : "connectors-badge class must be present in metricshub-connectors-directory.html"
+assert directoryHtmlText.indexOf("class=\"technology-label label label-default\"") > -1 : "technology-label class must be present in metricshub-connectors-directory.html"
 assert directoryHtmlText.indexOf("class=\"platform-tile-container\"") > -1 : "platform-tile-container class must be present in metricshub-connectors-directory.html"
 assert directoryHtmlText.indexOf("class=\"platform-tile\"") > -1 : "platform-tile class must be present in metricshub-connectors-directory.html"
 assert directoryHtmlText.indexOf("class=\"platform-title\"") > -1 : "platform-title class must be present in metricshub-connectors-directory.html"
+assert directoryHtmlText.indexOf("class=\"platform-title-text\"") > -1 : "platform-title-text class must be present in metricshub-connectors-directory.html"
 assert directoryHtmlText.indexOf("class=\"platform-icon\"") > -1 : "platform-icon must be present in metricshub-connectors-directory.html"
 assert directoryHtmlText.indexOf("alt=\"inline\"") > -1 : "alt=\"inline\" attribute must be present in metricshub-connectors-directory.html"
 
 // Define regex patterns to check
 def regexps = [
-    /class="connectors-badge badge"/,
+    /class="connectors-badge"/,
+    /class="badge"/,
     /class="platform-tile"/,
     /class="platform-title"/,
+    /class="platform-title-text"/,
     /class="platform-icon"/,
     /alt="inline"/
 ]

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/ConnectorPageProducer.java
@@ -540,7 +540,7 @@ public class ConnectorPageProducer {
 			yamlBuilder.append("            community: public # or probably something more secure");
 		}
 
-		if (technologies.contains(TechnologyType.COMMAND_LINES)) {
+		if (technologies.contains(TechnologyType.COMMANDS)) {
 			if (OsType.WINDOWS.getPossibleHostType().equals(hostType)) {
 				cli.append(" --wmi -u USER");
 				yamlBuilder.append(WMI_SECTION);

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/PlatformsPageProducer.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/PlatformsPageProducer.java
@@ -104,7 +104,15 @@ public class PlatformsPageProducer {
 			mainSink.link(platformSubdirectory + "/" + platformId + ".html", SinkHelper.setClass("platform-tile"));
 
 			mainSink.division(SinkHelper.setClass("platform-title"));
+
+			mainSink.division(SinkHelper.setClass("platform-title-text"));
 			mainSink.text(displayName);
+			mainSink.division_();
+
+			mainSink.division(SinkHelper.setClass("connectors-badge"));
+			mainSink.rawText(SinkHelper.bootstrapBadge(String.valueOf(numberOfConnectors), null));
+			mainSink.division_();
+
 			mainSink.division_();
 
 			mainSink.figure(SinkHelper.setClass("platform-icon"));
@@ -112,13 +120,12 @@ public class PlatformsPageProducer {
 			mainSink.figureGraphics(iconPath, SinkHelper.setAttribute(SinkEventAttributes.ALT, "inline"));
 			mainSink.figure_();
 
-			mainSink.division(SinkHelper.setClass("platform-badges"));
-			mainSink.rawText(SinkHelper.bootstrapBadge(String.valueOf(numberOfConnectors), "connectors-badge"));
+			mainSink.division(SinkHelper.setClass("platform-labels"));
 			platform
 				.getTechnologies()
 				.stream()
 				.map(TechnologyType::getDisplayName)
-				.forEach(technology -> mainSink.rawText(SinkHelper.bootstrapBadge(technology, "technology-badge")));
+				.forEach(technology -> mainSink.rawText(SinkHelper.bootstrapLabel(technology, "technology-label")));
 			mainSink.division_();
 
 			mainSink.link_();

--- a/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java
+++ b/src/main/java/org/sentrysoftware/maven/metricshub/connector/producer/model/common/TechnologyType.java
@@ -41,9 +41,9 @@ public enum TechnologyType {
 	IPMI("IPMI"),
 
 	/**
-	 * Command Lines
+	 * Commands
 	 */
-	COMMAND_LINES("Command Lines"),
+	COMMANDS("Commands"),
 
 	/**
 	 * Simple Network Management Protocol (SNMP)
@@ -80,8 +80,8 @@ public enum TechnologyType {
 	private static final Map<String, TechnologyType> TECHNOLOGY_TYPE_MAP = Map.of(
 		"http", HTTP,
 		"ipmi", IPMI,
-		"oscommand", COMMAND_LINES,
-		"commandline", COMMAND_LINES,
+		"oscommand", COMMANDS,
+		"commandline", COMMANDS,
 		"snmptable", SNMP,
 		"snmpget", SNMP,
 		"wbem", WBEM,


### PR DESCRIPTION
* N° of connectors is now displayed as badge next the platform title.
* Updated the technology badges as `label label-default`
* Renamed technology `Command Lines` to `Commands`
-----------
#### Testing
![platforms](https://github.com/user-attachments/assets/976e0f28-73f6-4979-92f3-69972412de6b)

